### PR TITLE
Add /build and /simplify commands for autonomous task execution

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,0 +1,127 @@
+# /build — Autonomous Build Orchestrator
+
+Execute the full plan from `tasks/todo.md` autonomously using TDD with sub-agent delegation.
+Bridges the gap between `/plan` (design) and `/wrap-up-session` (close).
+
+## Pre-Flight Checks
+
+1. Verify `tasks/todo.md` exists and has pending `[ ]` tasks
+   - If empty or missing: **STOP** — run `/plan` first
+2. Read the spec from `specs/` that matches the current plan
+   - If no spec found: **STOP** — run `/plan` first
+3. Load `tasks/lessons.md` and `.claude/memory.md` for context
+4. Identify the project's test runner and build tooling (check `package.json`, `Makefile`, `pyproject.toml`, etc.)
+5. Run the full test suite once to establish a **green baseline**
+   - If tests fail before you start: fix or flag to user before proceeding
+
+## Phase 1 — Task Execution (TDD Loop)
+
+Process every `[ ]` task in `tasks/todo.md` **without pausing for user confirmation between tasks**.
+
+For each `[ ] TDD: [Test Name] -> [Impl Detail]`:
+
+### Step 1 — Delegate to Sub-Agent
+
+Choose the appropriate sub-agent based on the task:
+
+| Task Type | Agent |
+|-----------|-------|
+| API, database, auth, business logic | `backend-developer` |
+| UI components, styling, client state | `frontend-developer` |
+| Cross-cutting or unclear | Use main context directly |
+
+**Delegation prompt must include:**
+- The exact task description from `tasks/todo.md`
+- The relevant section of the spec from `specs/`
+- Paths to related source files
+- Instruction: "Follow TDD — write failing test first, then minimal implementation, then refactor"
+
+### Step 2 — Verify Sub-Agent Output
+
+After the sub-agent returns:
+1. Run the new test — confirm it **passes**
+2. Run the **full test suite** — confirm no regressions
+3. If failures: delegate to `code-debugger` agent with failure output and context
+4. Repeat until green
+
+### Step 3 — Mark Complete
+- Change `[ ]` to `[x]` in `tasks/todo.md`
+- Log: `✓ [Test Name] — [one-line summary]`
+
+### Step 4 — Continue
+- Move to the next `[ ]` task immediately (no user prompt)
+- If a task is blocked by a previous failure, note it and skip to the next unblocked task
+
+## Phase 2 — Full Suite Validation
+
+After all tasks are `[x]`:
+
+1. Run the **complete test suite**
+2. Run linter / type checker if configured
+3. Confirm all tests pass and no errors
+4. If anything fails: delegate to `code-debugger` to fix, then re-run
+
+## Phase 3 — Simplify
+
+Run `/simplify` on all changed files:
+1. Identify changed files via `git diff --name-only` (against the baseline before build started)
+2. Invoke the `/simplify` skill to review for:
+   - Code reuse opportunities
+   - Clean Code violations (functions >20 LOC, >3 params, poor naming)
+   - SOLID principle violations
+   - Unnecessary complexity or dead code
+3. Apply suggested improvements
+4. Re-run full test suite to confirm simplifications didn't break anything
+
+## Phase 4 — Spec Validation
+
+Compare what was built against the original spec:
+
+1. Re-read `specs/[feature-name].md`
+2. Walk through each **Acceptance Criterion**:
+   - For each criterion: identify the test(s) that prove it
+   - Mark: `✅ [criterion]` or `❌ [criterion] — [what's missing]`
+3. If any criterion is `❌`:
+   - Create new `[ ]` task in `tasks/todo.md` for the gap
+   - Loop back to **Phase 1** for those tasks only
+4. When all criteria are `✅`: proceed to report
+
+## Phase 5 — Build Report
+
+Output the final report to the user:
+
+```
+══════════════════════════════════════
+  BUILD COMPLETE — [Feature Name]
+══════════════════════════════════════
+
+📋 Tasks: [X] completed, [Y] added during build
+🧪 Tests: [N] total, [N] passing, [0] failing
+📐 Spec Validation: [all criteria met / N gaps remain]
+🧹 Simplify: [N improvements applied]
+
+Files Changed:
+  [git diff --stat summary]
+
+Acceptance Criteria:
+  ✅ [criterion 1]
+  ✅ [criterion 2]
+  ...
+
+Ready for /wrap-up-session or manual QA.
+══════════════════════════════════════
+```
+
+## Error Handling
+
+- **Sub-agent failure**: Retry once with additional context. If still failing, surface the error to user and pause.
+- **Test regression**: Delegate to `code-debugger` with full failure output. Max 3 fix attempts per regression before escalating to user.
+- **Spec gap found late**: Add tasks dynamically and loop back. Do not silently skip criteria.
+- **Build tool missing**: Ask user for the correct command rather than guessing.
+
+## Key Principles
+
+- **Autonomous**: No user prompts between tasks. Run to completion or until blocked.
+- **Observable**: Log every task completion so progress is visible.
+- **Safe**: Full test suite after every task. Never let regressions accumulate.
+- **Spec-faithful**: The spec is the contract. Build is not done until every acceptance criterion has a passing test.

--- a/.claude/commands/simplify.md
+++ b/.claude/commands/simplify.md
@@ -1,0 +1,75 @@
+# /simplify — Code Simplification Review
+
+Review recently changed code for reuse opportunities, quality issues, and unnecessary complexity. Fix any issues found.
+
+## Scope
+
+Determine files to review:
+1. If invoked with a file path argument: review that file
+2. Otherwise: review all changed files via `git diff --name-only HEAD~1..HEAD` and `git diff --name-only` (staged + unstaged)
+3. Skip generated files, lock files, and test files (tests are reviewed only for duplication)
+
+## Review Checklist
+
+For each file, check:
+
+### 1. Code Reuse
+- **Duplicated logic** across files or within the same file → extract shared function/module
+- **Copy-pasted patterns** with minor variations → parameterize into a single function
+- **Existing utilities** that already do what new code does → replace with the existing utility
+
+### 2. Clean Code Violations
+- Functions **>20 LOC** → split into smaller, focused functions
+- Functions with **>3 parameters** → use an options object/dataclass
+- **Poor naming**: abbreviations, generic names (`data`, `info`, `tmp`, `result`) → rename to reveal intent
+- **Mixed abstraction levels** in a single function → separate high-level flow from low-level detail
+- **Dead code**: unreachable branches, unused imports, commented-out code → remove entirely
+
+### 3. SOLID Violations
+- **Single Responsibility**: class/function does more than one thing → split
+- **Open/Closed**: new behavior added via `if/else` chains → refactor to strategy/registry pattern
+- **Dependency Inversion**: hard-coded dependencies → inject via constructor/parameter
+
+### 4. Unnecessary Complexity
+- **Over-abstraction**: wrapper classes/functions that add no value → inline them
+- **Premature generalization**: configurable code with only one configuration → simplify to the concrete case
+- **Defensive code for impossible cases**: validation of internal values that are already guaranteed → remove
+- **Feature flags or backwards-compat shims** for removed features → clean up
+
+### 5. Efficiency
+- **Redundant computations**: same value calculated multiple times → compute once and reuse
+- **N+1 patterns**: loops making individual calls that could be batched → batch
+- **Unnecessary allocations**: building large intermediate structures when streaming/iterating would suffice
+
+## Process
+
+1. **Read** each file in scope
+2. **List issues** found with file path, line range, and category
+3. **Fix** each issue directly (edit the file)
+4. **Re-run tests** after all fixes to confirm nothing broke
+5. If tests fail after a simplification: **revert that change** and move on
+
+## Output
+
+```
+══════════════════════════════════
+  SIMPLIFY — [N] files reviewed
+══════════════════════════════════
+
+Changes Applied:
+  - [file:line] [category] — [short description of change]
+  - [file:line] [category] — [short description of change]
+
+No Issues:
+  - [files that were already clean]
+
+Tests: [PASS / FAIL — reverted N changes]
+══════════════════════════════════
+```
+
+## Principles
+
+- **Only simplify, never add features.** This is a reduction pass, not an enhancement.
+- **Preserve behavior.** Every change must be test-verified.
+- **Small edits.** One logical change at a time so failures are easy to isolate.
+- **Trust the tests.** If tests pass after simplification, the change is safe. If they fail, revert.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ At the start of every session:
 
 ---
 
-## Workflow: Spec → Plan → TDD
+## Workflow: Spec → Plan → Build → Wrap Up
 
 ### 1. Spec First
 For every non-trivial feature, distill the request into a formal Spec before writing any code:
@@ -24,12 +24,14 @@ For every non-trivial feature, distill the request into a formal Spec before wri
 - Ask user: _"Does this plan meet your requirements? Confirm with 'y' to begin."_
 - **Do not proceed without user confirmation**
 
-### 3. TDD Loop
-For every task in `tasks/todo.md`:
-1. Write a failing test → confirm it fails
-2. Write minimal code to pass → confirm it passes
-3. Refactor against Clean Code principles
-4. Mark `[x]` in `tasks/todo.md`
+### 3. Build (Autonomous Execution)
+Run `/build` to execute the plan autonomously:
+- Delegates tasks to appropriate sub-agents (`backend-developer`, `frontend-developer`, etc.)
+- Each task follows TDD: failing test → minimal impl → refactor → mark `[x]`
+- Full test suite after every task (no regressions)
+- Runs `/simplify` on all changed files when tasks are done
+- Validates every acceptance criterion from the spec
+- Reports results — no user prompts between tasks
 
 ### 4. Wrap Up
 After any user correction: note the root cause in `tasks/lessons.md`.
@@ -64,7 +66,9 @@ Invoke with `/skill-name` in the chat.
 | Skill | Purpose |
 |-------|---------|
 | `/plan` | Interview user, write spec, create task breakdown in `tasks/todo.md` |
-| `/tdd` | Execute TDD loop for tasks in `tasks/todo.md` |
+| `/build` | Autonomous orchestrator: TDD + sub-agents + simplify + spec validation |
+| `/tdd` | Execute TDD loop for tasks in `tasks/todo.md` (manual, with user checkpoints) |
+| `/simplify` | Review changed code for reuse, quality, complexity; fix issues found |
 | `/learn` | Extract session patterns and persist to `.claude/memory.md` |
 | `/checkpoint` | Snapshot progress to `tasks/checkpoint.md` for handoff or pause |
 | `/security-scan` | OWASP-focused audit on recently changed files |


### PR DESCRIPTION
## Summary

Introduces two new command workflows to improve development velocity and code quality:

1. **`/build`** — Autonomous build orchestrator that executes the full task plan from `tasks/todo.md` using TDD with sub-agent delegation, eliminating manual checkpoints between tasks
2. **`/simplify`** — Code review and refactoring tool that identifies and fixes quality issues, duplication, and unnecessary complexity in changed files

Updates the main workflow documentation to reflect the new Spec → Plan → Build → Wrap Up pipeline.

## Key Changes

- **`.claude/commands/build.md`** (new)
  - 5-phase autonomous execution: task execution (TDD loop), full suite validation, simplification, spec validation, and build reporting
  - Sub-agent delegation strategy for backend, frontend, and cross-cutting tasks
  - Automatic test verification after each task with regression detection
  - Dynamic task creation if spec gaps are discovered during build
  - Comprehensive error handling and retry logic

- **`.claude/commands/simplify.md`** (new)
  - Scoped file review (explicit path, git diff, or all changed files)
  - 5-category checklist: code reuse, Clean Code violations, SOLID principles, unnecessary complexity, and efficiency
  - Direct in-place fixes with test verification
  - Revert-on-failure safety mechanism

- **`CLAUDE.md`** (modified)
  - Updated workflow title from "Spec → Plan → TDD" to "Spec → Plan → Build → Wrap Up"
  - Clarified `/build` as the primary autonomous execution path (replacing manual `/tdd` loop)
  - Added `/simplify` to the skills table with purpose description
  - Noted that `/tdd` remains available for manual, checkpoint-based execution

## Notable Details

- `/build` runs the full test suite after every task to catch regressions immediately
- Sub-agent delegation includes context (spec sections, file paths, TDD instructions) to ensure quality output
- Spec validation is built into the build process — acceptance criteria must have passing tests before build is considered complete
- `/simplify` is integrated into `/build` as Phase 3, but can also be invoked standalone
- Both commands emphasize observability (detailed logging) and safety (test verification after every change)

https://claude.ai/code/session_01Pg4iY8P3nUjYphJNeKRznn