### PR TITLE
Add model routing rules and YAML frontmatter to agents

### DIFF
--- a/.claude/agents/planner.md
+++ b/.claude/agents/planner.md
@@ -1,3 +1,9 @@
+---
+name: planner
+description: Spec writing, task breakdown, architecture decisions
+model: opus
+---
+
 # Planner Agent
 
 You are an elite **Planning & Architecture Agent**. Your role is to transform vague feature requests or bug reports into precise, actionable specifications and TDD-ready task plans — before any code is written.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,3 +1,9 @@
+---
+name: security-reviewer
+description: OWASP checks, auth flows, injection vectors
+model: sonnet
+---
+
 # Security Reviewer Agent
 
 You are a **Senior Application Security Engineer** specializing in code-level security review. Your job is to identify vulnerabilities in changed code before it reaches production — not to do broad audits, but to focus precisely on what was modified.

--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -3,6 +3,13 @@
 Execute the full plan from `tasks/todo.md` autonomously using TDD with sub-agent delegation.
 Bridges the gap between `/plan` (design) and `/wrap-up-session` (close).
 
+## Model Routing
+
+**This command MUST use `model: sonnet` for all sub-agent delegations.**
+- All coding agents (`backend-developer`, `frontend-developer`, `code-debugger`, `code-reviewer`) MUST be invoked with `model: "sonnet"`
+- For codebase searches and file exploration, use `model: "haiku"` via the Explore agent
+- Never use `opus` during build — it is reserved for planning and architecture
+
 ## Pre-Flight Checks
 
 1. Verify `tasks/todo.md` exists and has pending `[ ]` tasks

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -2,6 +2,13 @@
 
 Enter plan mode to define a spec and task breakdown **before any code is written**.
 
+## Model Routing
+
+**This command MUST use `model: opus` for all agent delegations.**
+- When spawning the `planner` agent, pass `model: "opus"` to the Agent tool
+- When performing codebase exploration or searches, use `model: "haiku"` for the Explore agent
+- The planning phase requires the strongest reasoning model for architecture decisions
+
 ## Steps
 
 ### 1. Interview the User

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,19 +43,46 @@ At session end: run `/wrap-up-session` to sync learnings, tests, and push.
 
 Use specialized agents to keep the main context window clean.
 
-| Agent | Best For |
-|-------|---------|
-| `planner` | Spec writing, task breakdown, architecture decisions |
-| `backend-developer` | APIs, databases, auth, performance, security |
-| `frontend-developer` | React/Vue/Angular components, responsive UI |
-| `frontend-design-validator` | Validate UI against design specs |
-| `code-reviewer` | Post-implementation quality review (invoke proactively) |
-| `code-debugger` | Debugging failing tests and runtime errors |
-| `security-reviewer` | OWASP checks, auth flows, injection vectors |
-| `content-generator-expert` | PDF pipeline, semantic search, recommendations |
-| `context-document-optimizer` | Compress large docs for token efficiency |
+| Agent | Model | Best For |
+|-------|-------|---------|
+| `planner` | `opus` | Spec writing, task breakdown, architecture decisions |
+| `backend-developer` | `sonnet` | APIs, databases, auth, performance, security |
+| `frontend-developer` | `sonnet` | React/Vue/Angular components, responsive UI |
+| `frontend-design-validator` | `sonnet` | Validate UI against design specs |
+| `code-reviewer` | `sonnet` | Post-implementation quality review (invoke proactively) |
+| `code-debugger` | `sonnet` | Debugging failing tests and runtime errors |
+| `security-reviewer` | `sonnet` | OWASP checks, auth flows, injection vectors |
+| `content-generator-expert` | `sonnet` | PDF pipeline, semantic search, recommendations |
+| `context-document-optimizer` | `sonnet` | Compress large docs for token efficiency |
 
 **Delegation rule**: Use subagents for research, exploration, and parallel analysis. One focused task per subagent.
+
+---
+
+## Model Routing Rules
+
+**These rules are mandatory for all agent delegations and tool invocations.**
+
+| Operation | Model | Rationale |
+|-----------|-------|-----------|
+| `/plan` — spec writing, architecture, task breakdown | `opus` | Strongest reasoning for design decisions |
+| `/build` — TDD, coding, debugging, code review | `sonnet` | Fast, capable coding model |
+| Codebase search, grep, file exploration | `haiku` | Fastest model for simple lookups |
+
+### Enforcement
+
+When invoking the **Agent tool**, always pass the `model` parameter:
+
+- **Planning agents** (`planner`): `model: "opus"`
+- **Coding agents** (`backend-developer`, `frontend-developer`, `code-reviewer`, `code-debugger`, `content-generator-expert`, `frontend-design-validator`, `context-document-optimizer`, `security-reviewer`): `model: "sonnet"`
+- **Explore agents** (codebase search, file discovery, grep): `model: "haiku"`
+
+### Rules
+
+1. **Never use `opus` for code writing** — it is reserved for planning and architecture
+2. **Never use `haiku` for code writing or planning** — it is for search/exploration only
+3. **Always pass `model` explicitly** — do not rely on defaults
+4. Agent YAML front-matter declares the intended model; the Agent tool `model` parameter enforces it
 
 ---
 


### PR DESCRIPTION
## Summary

This PR establishes explicit model routing rules across the agent system to optimize token usage and task performance. It adds YAML frontmatter to agent definitions and documents mandatory model selection guidelines for all agent delegations and tool invocations.

## Key Changes

- **Added Model Routing Rules section** to `CLAUDE.md` with a mandatory enforcement table specifying which Claude model (`opus`, `sonnet`, `haiku`) to use for different operation types:
  - `opus` for planning, spec writing, and architecture decisions
  - `sonnet` for coding, debugging, and code review
  - `haiku` for codebase search and file exploration

- **Updated agent table** in `CLAUDE.md` to include a new `Model` column showing the assigned model for each agent

- **Added YAML frontmatter** to agent definitions:
  - `planner.md`: `model: opus`
  - `security-reviewer.md`: `model: sonnet`

- **Added Model Routing sections** to command documentation:
  - `/plan.md`: Enforces `model: opus` for planning delegations, `model: haiku` for exploration
  - `/build.md`: Enforces `model: sonnet` for all coding agents, `model: haiku` for codebase searches

- **Documented enforcement rules** with three explicit constraints:
  1. Never use `opus` for code writing
  2. Never use `haiku` for code writing or planning
  3. Always pass `model` parameter explicitly to the Agent tool

## Implementation Details

The model routing rules are designed to be mandatory across all agent delegations. The YAML frontmatter in agent files serves as the source of truth for intended model assignment, while the Agent tool's `model` parameter enforces the routing at invocation time. This prevents model misuse and optimizes cost/performance tradeoffs.

https://claude.ai/code/session_01FSirb27EKFJPruQSuLbb2R