### PR TITLE
Migrate commands to skills format with YAML frontmatter

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: build
+description: Execute the task plan from tasks/todo.md autonomously using TDD with sub-agent delegation. Use after /plan is confirmed.
+disable-model-invocation: true
+---
+
 # /build — Autonomous Build Orchestrator
 
 Execute the full plan from `tasks/todo.md` autonomously using TDD with sub-agent delegation.

--- a/.claude/skills/checkpoint/SKILL.md
+++ b/.claude/skills/checkpoint/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: checkpoint
+description: Snapshot current session progress to tasks/checkpoint.md for handoff or pause.
+---
+
 # /checkpoint — Session Checkpoint
 
 Save a snapshot of current progress for handoff, pause, or context compaction.

--- a/.claude/skills/learn/SKILL.md
+++ b/.claude/skills/learn/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: learn
+description: Extract durable patterns from the current session and persist to memory.md and lessons.md.
+---
+
 # /learn — Capture Session Learnings
 
 Extract durable patterns from this session and persist them into `.claude/memory.md` and `tasks/lessons.md`.

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: plan
+description: Interview user, write a feature spec, and create a TDD task breakdown. Use for any non-trivial feature before coding.
+argument-hint: "[feature description]"
+disable-model-invocation: true
+---
+
 # /plan — Structured Spec + Plan Mode
 
 Enter plan mode to define a spec and task breakdown **before any code is written**.

--- a/.claude/skills/security-scan/SKILL.md
+++ b/.claude/skills/security-scan/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: security-scan
+description: OWASP-focused security audit on recently changed files. Use after code changes to check for vulnerabilities.
+---
+
 # /security-scan — Security Review
 
 Run a focused security audit on recently changed code before committing or deploying.

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: simplify
+description: Review changed code for reuse, clean code, and SOLID violations, then fix issues found.
+argument-hint: "[optional file path]"
+---
+
 # /simplify — Code Simplification Review
 
 Review recently changed code for reuse opportunities, quality issues, and unnecessary complexity. Fix any issues found.

--- a/.claude/skills/start-qa/SKILL.md
+++ b/.claude/skills/start-qa/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: start-qa
+description: Discover project config, restart app, and launch browser for manual QA testing.
+disable-model-invocation: true
+---
+
 # /start-qa — Start QA Session
 
 Restart the application, launch a browser for manual QA as fast as possible, and run health/smoke checks in the background.

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -1,6 +1,11 @@
+---
+name: sync
+description: Pull latest skills, hooks, agents, and config from the coding-agent-workflow template repo.
+---
+
 # /sync — Sync Workflow Updates from Template Repo
 
-Pull the latest skills, commands, hooks, agents, and config from the `coding-agent-workflow` template repo into the current project.
+Pull the latest skills, hooks, agents, and config from the `coding-agent-workflow` template repo into the current project.
 
 ## Source Repo
 
@@ -12,7 +17,7 @@ Pull the latest skills, commands, hooks, agents, and config from the `coding-age
 These are the files/directories managed by the workflow template:
 
 ```
-.claude/commands/     → Skills (slash commands)
+.claude/skills/       → Skills (slash commands)
 .claude/agents/       → Subagent definitions
 .claude/hooks/        → Lifecycle hooks
 .claude/settings.json → Hook configuration
@@ -60,12 +65,12 @@ Compare the syncable paths between the current project and the template source.
 **If git remote mode:**
 ```bash
 # Show changed files in syncable paths only
-git diff HEAD...workflow/main --stat -- .claude/commands/ .claude/agents/ .claude/hooks/ .claude/settings.json CLAUDE.md conductor/
+git diff HEAD...workflow/main --stat -- .claude/skills/ .claude/agents/ .claude/hooks/ .claude/settings.json CLAUDE.md conductor/
 ```
 
 Then show the full diff:
 ```bash
-git diff HEAD...workflow/main -- .claude/commands/ .claude/agents/ .claude/hooks/ .claude/settings.json CLAUDE.md conductor/
+git diff HEAD...workflow/main -- .claude/skills/ .claude/agents/ .claude/hooks/ .claude/settings.json CLAUDE.md conductor/
 ```
 
 **If manual diff mode:**
@@ -78,7 +83,7 @@ Summarize the changes in a clear table:
 ```
 | File                          | Status   | Summary                    |
 |-------------------------------|----------|----------------------------|
-| .claude/commands/sync.md      | NEW      | New sync command            |
+| .claude/skills/sync/SKILL.md  | NEW      | New sync skill              |
 | .claude/agents/planner.md     | MODIFIED | Updated planning prompts    |
 | CLAUDE.md                     | MODIFIED | Added new workflow section  |
 ```

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: tdd
+description: Execute TDD loop for tasks in tasks/todo.md with user checkpoints between steps.
+---
+
 # /tdd — TDD Workflow
 
 Execute the TDD loop for tasks in `tasks/todo.md`.

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -1,3 +1,9 @@
+---
+name: wrap-up-session
+description: Close session: sync learnings, update registers, run tests, and push.
+disable-model-invocation: true
+---
+
 # /wrap-up-session — Session Wrap-Up
 
 Close out the session by syncing learnings, updating task and bug registers, running tests, and pushing changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,9 +86,9 @@ When invoking the **Agent tool**, always pass the `model` parameter:
 
 ---
 
-## Skills — `.claude/commands/` & `.claude/skills/`
+## Skills — `.claude/skills/`
 
-Invoke with `/skill-name` in the chat.
+Invoke with `/skill-name` in the chat. Each skill is a directory under `.claude/skills/` containing a `SKILL.md` with YAML frontmatter.
 
 | Skill | Purpose |
 |-------|---------|
@@ -102,7 +102,7 @@ Invoke with `/skill-name` in the chat.
 | `/security-scan` | OWASP-focused audit on recently changed files |
 | `/start-qa` | Restart app, health check, launch browser with log monitoring for manual QA |
 | `/wrap-up-session` | Sync learnings, update task/bug registers, run tests, push to main |
-| `/sync` | Pull latest skills, commands, hooks, agents from the template repo into the current project |
+| `/sync` | Pull latest skills, hooks, agents from the template repo into the current project |
 
 ---
 
@@ -153,7 +153,7 @@ Before marking any task complete, confirm:
 
 ```
 .claude/agents/     → Specialized subagents (invoked via Agent tool)
-.claude/commands/   → Skills invokable with /command-name
+.claude/skills/     → Skills invokable with /skill-name
 .claude/hooks/      → Lifecycle automation scripts
 tasks/todo.md       → Active task plan (single source of truth)
 tasks/bugs.md       → Bug register (opened/fixed per session)

--- a/specs/commands-to-skills-migration.md
+++ b/specs/commands-to-skills-migration.md
@@ -1,0 +1,55 @@
+# Spec: Migrate Commands to Skills Format
+
+## Behavior
+Convert all 10 command files in `.claude/commands/` to the skills directory format under `.claude/skills/`. Each command becomes a skill directory containing a `SKILL.md` file with YAML frontmatter. The old command files are removed. `CLAUDE.md` is updated to reflect the new structure. User-facing invocation (`/plan`, `/build`, etc.) remains unchanged.
+
+## Inputs
+- 10 existing command files in `.claude/commands/`
+- 1 existing skill (`debug`) as the reference format
+- `CLAUDE.md` referencing the old structure
+
+## Outputs
+- 10 new skill directories under `.claude/skills/`, each with `SKILL.md`
+- Old `.claude/commands/` directory removed
+- `CLAUDE.md` updated (directory references, skills table)
+- `/sync` command updated to sync `.claude/skills/` instead of `.claude/commands/`
+
+## YAML Frontmatter Mapping
+
+Each skill gets frontmatter based on its behavior:
+
+| Command | `name` | `description` (for auto-invocation) | `argument-hint` | `disable-model-invocation` |
+|---------|--------|--------------------------------------|------------------|----------------------------|
+| build | build | Execute the task plan from tasks/todo.md autonomously using TDD with sub-agent delegation. Use after /plan is confirmed. | — | true |
+| checkpoint | checkpoint | Snapshot current session progress to tasks/checkpoint.md for handoff or pause. | — | false |
+| learn | learn | Extract durable patterns from the current session and persist to memory.md and lessons.md. | — | false |
+| plan | plan | Interview user, write a feature spec, and create a TDD task breakdown. Use for any non-trivial feature before coding. | "[feature description]" | true |
+| security-scan | security-scan | OWASP-focused security audit on recently changed files. Use after code changes to check for vulnerabilities. | — | false |
+| simplify | simplify | Review changed code for reuse, clean code, and SOLID violations, then fix issues found. | "[optional file path]" | false |
+| start-qa | start-qa | Discover project config, restart app, and launch browser for manual QA testing. | — | true |
+| sync | sync | Pull latest skills, hooks, agents, and config from the coding-agent-workflow template repo. | — | false |
+| tdd | tdd | Execute TDD loop for tasks in tasks/todo.md with user checkpoints between steps. | — | false |
+| wrap-up-session | wrap-up-session | Close session: sync learnings, update registers, run tests, and push. | — | true |
+
+### `disable-model-invocation` rationale
+Set to `true` for orchestrator skills that primarily delegate to sub-agents (`build`, `plan`, `start-qa`, `wrap-up-session`). These coordinate work rather than performing it directly.
+
+## Edge Cases
+- `/sync` currently syncs `.claude/commands/` — must be updated to sync `.claude/skills/` instead
+- `CLAUDE.md` references `.claude/commands/` in multiple places — all must be updated
+- The `debug` skill already exists and must not be touched
+- Command content (below the frontmatter) stays identical — no prompt changes
+
+## Acceptance Criteria
+- [ ] All 10 commands exist as `.claude/skills/[name]/SKILL.md` with correct YAML frontmatter
+- [ ] `.claude/commands/` directory is removed
+- [ ] `CLAUDE.md` references updated from `commands` to `skills`
+- [ ] `/sync` skill references `.claude/skills/` instead of `.claude/commands/`
+- [ ] `debug` skill is unchanged
+- [ ] All skills are invokable via `/name` (same UX as before)
+
+## Files Involved
+- `.claude/commands/*.md` — source files (10, to be deleted)
+- `.claude/skills/*/SKILL.md` — target files (10, to be created)
+- `CLAUDE.md` — update directory references and skills table
+- `.claude/commands/sync.md` → `.claude/skills/sync/SKILL.md` — update sync paths

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,9 @@
+## Plan: Migrate Commands to Skills Format
+> Spec: specs/commands-to-skills-migration.md
+
+[ ] Create skill directories and SKILL.md for: build, checkpoint, learn, plan, security-scan, simplify, start-qa, sync, tdd, wrap-up-session (add YAML frontmatter, preserve prompt content)
+[ ] Update sync skill to reference `.claude/skills/` instead of `.claude/commands/`
+[ ] Update CLAUDE.md to replace all `.claude/commands/` references with `.claude/skills/`
+[ ] Remove `.claude/commands/` directory
+[ ] Verify debug skill is unchanged
+[ ] Verify all skills are listed in system and invokable


### PR DESCRIPTION
## Summary
This PR migrates the 10 command files from `.claude/commands/` to the skills directory format under `.claude/skills/`, establishing a new standardized structure with YAML frontmatter while preserving all existing functionality and user-facing invocation patterns.

## Key Changes
- **New spec document** (`specs/commands-to-skills-migration.md`): Comprehensive specification defining the migration strategy, YAML frontmatter mapping for all 10 commands, and acceptance criteria
- **Task breakdown** (`tasks/todo.md`): Detailed checklist for executing the migration, including:
  - Creating skill directories with `SKILL.md` files and YAML frontmatter for: build, checkpoint, learn, plan, security-scan, simplify, start-qa, sync, tdd, wrap-up-session
  - Updating the sync skill to reference `.claude/skills/` instead of `.claude/commands/`
  - Updating `CLAUDE.md` documentation
  - Removing the old `.claude/commands/` directory

## Implementation Details
- **YAML frontmatter mapping**: Each skill receives metadata including `name`, `description`, `argument-hint`, and `disable-model-invocation` flag based on its role
- **Orchestrator skills** (build, plan, start-qa, wrap-up-session) are marked with `disable-model-invocation: true` since they primarily delegate to sub-agents
- **Backward compatibility**: User-facing invocation (`/plan`, `/build`, etc.) remains unchanged
- **Reference format**: The existing `debug` skill serves as the structural template and is left untouched
- **Content preservation**: All command prompts and logic remain identical—only the directory structure and frontmatter are modified

This migration establishes a consistent, scalable format for managing Claude skills while maintaining full backward compatibility with existing workflows.

https://claude.ai/code/session_012nzjsu27cuVoQFnnGZX8XY