### PR TITLE
feat: add /prd skill with backlog and project-context

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -22,8 +22,9 @@ Bridges the gap between `/plan` (design) and `/wrap-up-session` (close).
 2. Read the spec from `specs/` that matches the current plan
    - If no spec found: **STOP** — run `/plan` first
 3. Load `tasks/lessons.md` and `.claude/memory.md` for context
-4. Identify the project's test runner and build tooling (check `package.json`, `Makefile`, `pyproject.toml`, etc.)
-5. Run the full test suite once to establish a **green baseline**
+4. **Load `tasks/project-context.md`** if it exists — this provides architecture, protection list, non-functional requirements, and conventions for sub-agent delegation
+5. Identify the project's test runner and build tooling (check `package.json`, `Makefile`, `pyproject.toml`, etc.)
+6. Run the full test suite once to establish a **green baseline**
    - If tests fail before you start: fix or flag to user before proceeding
 
 ## Phase 1 — Task Execution (TDD Loop)
@@ -80,6 +81,18 @@ Choose the appropriate sub-agent based on the task:
 - The relevant section of the spec from `specs/`
 - Paths to related source files
 - Instruction: "Follow TDD — write failing test first, then minimal implementation, then refactor"
+
+**Role-based context injection from `tasks/project-context.md`** (if it exists):
+
+| Agent Type | Sections to Include |
+|---|---|
+| `backend-developer` | `[ARCHITECTURE]` + `[PROTECTION]` + relevant functional requirements from spec |
+| `frontend-developer` | `[ARCHITECTURE]` + `[PROTECTION]` + `[CONVENTIONS]` + relevant functional requirements from spec |
+| `code-reviewer` | Feature spec + coding standards only — no project-context needed |
+| `code-debugger` | Failing test + relevant code only — no project-context needed |
+| `security-reviewer` | `[ARCHITECTURE]` + `[NON-FUNCTIONAL]` |
+
+Do NOT pass the full project-context to every agent. Extract only the relevant sections to keep agent context focused.
 
 ### Step 2 — Two-Stage Review
 
@@ -169,7 +182,14 @@ Compare what was built against the original spec:
    - Loop back to **Phase 1** for those tasks only
 4. When all criteria are `✅`: proceed to report
 
-## Phase 5 — Build Report
+## Phase 5 — Backlog Update
+
+If `tasks/backlog.md` exists:
+1. Identify which backlog item this build corresponds to (from the spec reference)
+2. Mark the item as `[x]` in `tasks/backlog.md`
+3. Update `tasks/project-context.md` `[CURRENT-PHASE]` section if the phase is now complete (all items `[x]`)
+
+## Phase 6 — Build Report
 
 Output the final report to the user:
 

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -17,6 +17,18 @@ Enter plan mode to define a spec and task breakdown **before any code is written
 
 ## Steps
 
+### 0. Pre-Flight — Context Loading
+
+Before interviewing, load available project context:
+
+1. **Check for `tasks/project-context.md`** — if exists, read it for broader project context (architecture, conventions, protection list)
+2. **Check for `tasks/backlog.md`** — if exists and an argument was provided:
+   - Match the argument against backlog item names
+   - If match found: use the backlog item description as the starting point for the spec
+   - Mark the item as `[~]` (in progress) in `tasks/backlog.md`
+   - If no match: list available `[ ]` items and ask user to pick one
+3. **If no backlog exists**: proceed normally (interview from scratch)
+
 ### 1. Interview the User
 Ask clarifying questions to fully understand the feature:
 - What is the desired behavior? What problem does it solve?
@@ -25,6 +37,8 @@ Ask clarifying questions to fully understand the feature:
 - What constraints exist (performance, security, backwards-compatibility)?
 - Which existing files/components are likely involved?
 - What does "done" look like? How will we verify it works?
+
+If working from a backlog item, use its description and the PRD context to pre-fill known answers. Only ask about gaps.
 
 Wait for complete answers before proceeding.
 
@@ -79,5 +93,24 @@ Show the user both the spec and the plan. Ask:
 
 **Do not write any code until the user confirms.**
 
-### 5. Hand Off to TDD
+### 5. Divergence Check
+
+If `tasks/project-context.md` exists, compare the new spec's decisions against it:
+
+- New dependencies or libraries not in the `[ARCHITECTURE]` section
+- Data model changes (new entities, changed relationships)
+- Contradictions with stated technical architecture
+- New non-functional requirements not in `[NON-FUNCTIONAL]`
+
+**If divergence detected**, prompt the user:
+> "This spec introduces [specific change, e.g., 'Redis for caching — not in current architecture']. Update the PRD and project context? (y/n)"
+
+If yes:
+1. Update only the affected sections in the source PRD (`specs/prd-*.md`)
+2. Regenerate `tasks/project-context.md` from the updated PRD
+3. Append the change to the PRD's Revision History table
+
+If no: note the divergence in the spec as a conscious decision and proceed.
+
+### 6. Hand Off to TDD
 After confirmation, proceed with `/tdd` or begin the TDD loop directly.

--- a/.claude/skills/prd/SKILL.md
+++ b/.claude/skills/prd/SKILL.md
@@ -1,0 +1,273 @@
+---
+name: prd
+description: Interview the user about a greenfield project, produce a structured PRD, ordered backlog, and agent context file. Use as the entry point for new projects.
+argument-hint: "[project idea or description]"
+---
+
+# /prd — Product Requirements Document Generator
+
+## Overview
+
+Entry point for greenfield projects. Interviews the user, produces a structured PRD, decomposes it into an ordered backlog, and generates a compressed project-context file for agent consumption.
+
+## Model Routing
+
+**This command MUST use `model: opus` for all agent delegations.**
+- PRD creation is a planning/architecture activity — requires strongest reasoning
+- For codebase exploration or searches, use `model: "haiku"` via the Explore agent
+
+## The Hard Gate
+
+```
+DO NOT invoke /plan, /build, /tdd, or write any code until the PRD is approved
+and the backlog is generated.
+```
+
+## Outputs
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `specs/prd-<name>.md` | Full PRD document | Humans + planning agents |
+| `tasks/backlog.md` | Ordered work items grouped by phase | Humans + `/plan` |
+| `tasks/project-context.md` | Compressed, section-labeled agent briefing | Sub-agents only |
+
+## The Process
+
+### Step 1 — Explore Existing Context
+
+- Read codebase structure if anything exists (package.json, directory layout, key files)
+- Read `.claude/memory.md` for prior decisions
+- Check if a PRD or backlog already exists:
+  - If PRD exists: ask "Update the existing PRD or create a new one?"
+  - If backlog exists with completed items: warn that regenerating will need to preserve `[x]` items
+
+### Step 2 — Hybrid Draft + Interview
+
+From the user's initial prompt and any existing context:
+
+1. **Draft a skeleton PRD** covering as many sections as possible from available information
+2. **Identify gaps** — sections where information is missing or ambiguous
+3. **Interview the user on gaps only**, one question at a time
+4. **Prefer multiple-choice questions** — faster for the user, reduces ambiguity
+5. Do NOT dump all questions at once. Ask one, wait for answer, then ask the next based on the response.
+
+Focus interview questions on:
+- Business context and problem (if not clear from prompt)
+- User personas and their key needs
+- Must-have vs. nice-to-have features
+- Technical constraints or preferences
+- Non-functional requirements (performance, security, scale)
+- What's explicitly out of scope
+
+### Step 3 — Write the PRD
+
+Write `specs/prd-<name>.md` with the following structure.
+
+Sections 1-8 are **traditional product requirements** (for humans and planning agents).
+Sections 9-11 are the **agent-optimization layer** (for decomposition and execution).
+
+```markdown
+# PRD: [Project Name]
+
+## 1. Overview
+- Project name and one-line description
+- Problem statement: what pain exists today
+- Vision: what the world looks like after this is built
+- Target users / personas (name, role, key need)
+
+## 2. Goals & Success Criteria
+- 3-5 measurable project goals
+- Definition of "done" for the overall project
+- Key metrics or outcomes that indicate success
+
+## 3. User Stories
+Grouped by feature area / persona.
+Format: As [persona], I want [action], so that [benefit]
+Priority: Must-have / Should-have / Nice-to-have (MoSCoW)
+
+## 4. Functional Requirements
+Organized by module or feature area.
+Each requirement has:
+- Description (what it does)
+- Acceptance criteria using EARS notation:
+  WHEN [condition] THE SYSTEM SHALL [behavior]
+- Priority (Must / Should / Nice)
+
+## 5. Non-Functional Requirements
+- Performance targets (response times, throughput)
+- Security requirements (auth, data protection, compliance)
+- Scalability expectations
+- Accessibility standards
+- Browser/device/platform support
+
+## 6. Technical Architecture
+- Tech stack (languages, frameworks, databases, infra)
+- System boundaries and integrations
+- Data model overview (key entities and relationships)
+- Key architectural decisions and rationale
+
+## 7. Out of Scope / Non-Goals
+- Explicit list of what this project does NOT include
+- Things that might seem implied but are deliberately excluded
+- Future considerations parked for later
+
+## 8. Dependencies & Assumptions
+- External services, APIs, third-party tools
+- Team/resource assumptions
+- Technical assumptions
+
+## 9. Phases & Dependency Order
+- Ordered phases, each ending in something verifiable
+- Each phase lists which functional requirements it addresses
+- Explicit dependencies: "Phase 2 requires Phase 1's API endpoints"
+- Phase sizing: each phase should be 1-3 specs worth of work
+
+## 10. Protection List
+- Files, systems, or patterns that must NOT be modified
+- Existing functionality that must be preserved
+- External contracts or APIs that cannot change
+(For greenfield: "No protected files — greenfield project.")
+
+## 11. Risks & Mitigations
+- Technical risks (new technology, complex integrations)
+- Scope risks (requirements likely to change)
+- Mitigation strategy for each
+
+## Revision History
+| Date | Section | Change | Trigger |
+|------|---------|--------|---------|
+| YYYY-MM-DD | Initial | PRD created | /prd |
+```
+
+### Step 4 — Self-Review
+
+Before presenting to the user, check the PRD for:
+- **No placeholders or TBD items** — resolve or remove them
+- **All acceptance criteria are boolean-testable** — EARS notation, no subjective language
+- **Non-goals section is populated** — AI cannot infer from omission
+- **Phases have clear dependency ordering** — no circular dependencies
+- **Protection list is populated** — even if minimal for greenfield
+- **No contradictions between sections**
+- **No ambiguous language** that could be interpreted multiple ways
+
+### Step 5 — User Review
+
+Present the full PRD. Ask:
+> "Does this PRD capture your requirements? I can adjust any section. Confirm with 'y' to generate the backlog."
+
+Iterate on feedback until approved. **Do not generate backlog without explicit approval.**
+
+### Step 6 — Generate Backlog
+
+Decompose the PRD into `tasks/backlog.md`:
+
+```markdown
+# Backlog: [Project Name]
+> PRD: specs/prd-<name>.md
+> Generated: YYYY-MM-DD
+
+## Phase 1: [Phase Name]
+> Dependencies: none
+> Verifiable outcome: [what you can demo/test when phase is done]
+
+- [ ] [Feature/module name] — [one-line description]
+- [ ] [Feature/module name] — [one-line description]
+
+## Phase 2: [Phase Name]
+> Dependencies: Phase 1
+> Verifiable outcome: [what you can demo/test when phase is done]
+
+- [ ] [Feature/module name] — [one-line description]
+- [ ] [Feature/module name] — [one-line description]
+```
+
+**Backlog item sizing rules:**
+- Each item is "spec-sized" — big enough to need `/plan` but small enough to be one coherent feature
+- Target: 3-8 items per phase, 2-5 phases per project
+- If >5 phases or >30 items: suggest splitting into multiple PRDs or calling out an MVP phase
+
+**Status conventions:**
+- `[ ]` — not started
+- `[~]` — in progress (being planned or built)
+- `[x]` — done
+
+### Step 7 — Generate Project Context
+
+Compress the PRD into `tasks/project-context.md` for selective agent injection:
+
+```markdown
+# Project Context: [Project Name]
+> Source PRD: specs/prd-<name>.md
+> Generated: YYYY-MM-DD — regenerate with /prd if PRD changes
+
+## [ARCHITECTURE]
+Tech stack, system boundaries, data model overview.
+Concise — facts only, no rationale.
+
+## [PROTECTION]
+Files and systems that must not be modified.
+
+## [NON-FUNCTIONAL]
+Performance, security, scalability, accessibility targets.
+
+## [CURRENT-PHASE]
+Which phase is active, what's been completed, what's next.
+
+## [CONVENTIONS]
+Naming conventions, patterns, coding standards specific to this project.
+```
+
+**Token efficiency rules:**
+- Strip rationale, keep facts
+- Use bullet points, not paragraphs
+- No section should exceed 20 lines
+- If a section is empty, write "None" — don't omit the header
+
+### Step 8 — Present Summary
+
+Show the user:
+
+```
+══════════════════════════════════════
+  PRD COMPLETE — [Project Name]
+══════════════════════════════════════
+
+📄 PRD: specs/prd-<name>.md
+📋 Backlog: tasks/backlog.md ([N] items across [M] phases)
+🤖 Agent Context: tasks/project-context.md
+
+Phase 1: [Phase Name] — [N] items
+Phase 2: [Phase Name] — [N] items
+...
+
+Suggested next step:
+  /plan [first-backlog-item-name]
+
+══════════════════════════════════════
+```
+
+## Updating an Existing PRD
+
+When `/prd` finds an existing PRD:
+
+1. Ask: "Update existing PRD or start fresh?"
+2. If updating:
+   - Show current PRD sections as a starting point
+   - Interview on what changed
+   - Update only affected sections
+   - Append to Revision History
+   - Regenerate `tasks/project-context.md`
+   - Regenerate `tasks/backlog.md` — preserve `[x]` items, update `[ ]` items
+3. If starting fresh:
+   - Archive old PRD to `specs/archive/prd-<name>-<date>.md`
+   - Proceed with normal flow
+
+## Key Principles
+
+- **Hybrid draft + interview** — draft from available context, interview on gaps only
+- **Boolean-testable criteria** — EARS notation, no subjective language
+- **Explicit non-goals** — AI cannot infer from omission
+- **Dependency ordering** — agents must know what to build first
+- **Living document** — PRD evolves via `/plan` divergence checks and `/wrap-up-session` staleness checks
+- **Two audiences** — full PRD for humans and planners, compressed context for coding agents
+- **Hard gate** — no code until PRD is approved and backlog is generated

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -42,6 +42,24 @@ Store the detected base branch and reference it as `<base-branch>` in all later 
 
 ---
 
+## Step 0.5 — Project Context Staleness Check
+
+If `tasks/project-context.md` exists, check for divergence between what was documented and what was actually built this session:
+
+1. **Dependencies**: Compare `package.json` / `pyproject.toml` / `go.mod` against the `[ARCHITECTURE]` section — new libraries added?
+2. **Structure**: Check for new directories or modules not reflected in `[ARCHITECTURE]` or `[CONVENTIONS]`
+3. **Patterns**: Look for changed auth approaches, new middleware, database changes via `git diff --name-only <base-branch>...HEAD`
+
+**If divergence found:**
+- **Auto-update `tasks/project-context.md`** — it's an agent-facing file, no user approval needed
+- **Flag PRD sections that may need updating** — show the user which sections are potentially stale and ask: _"These PRD sections may be outdated: [list]. Update them now? (y/n)"_
+- If yes: update only the affected sections in `specs/prd-*.md` and append to the Revision History
+- If no: proceed — the user can update later
+
+**If no divergence or no project-context file:** skip to Step 1.
+
+---
+
 ## Step 1 — Capture Learnings
 
 Run the `/learn` skill to:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,19 @@ At the start of every session:
 
 ---
 
-## Workflow: Spec → Plan → Build → Wrap Up
+## Workflow: PRD → Plan → Build → Wrap Up
+
+### 0. PRD (Greenfield Projects Only)
+For new projects, start with `/prd` to interview and produce:
+- `specs/prd-<name>.md` — full Product Requirements Document
+- `tasks/backlog.md` — ordered work items grouped by phase
+- `tasks/project-context.md` — compressed agent briefing (auto-updated, never edit manually)
 
 ### 1. Spec First
-For every non-trivial feature, distill the request into a formal Spec before writing any code:
+For every non-trivial feature (or backlog item), distill the request into a formal Spec before writing any code:
 - Create `specs/[feature-name].md` with: Behavior / Inputs / Outputs / Edge Cases / Acceptance Criteria
 - Use the `/plan` skill to run this interactively with the user
+- `/plan` accepts an optional backlog item argument: `/plan <item-name>`
 
 ### 2. Plan Before Code (Hard Gate)
 - Write a step-by-step plan to `tasks/todo.md` before touching any source code
@@ -91,8 +98,9 @@ Invoke with `/skill-name` in the chat. Each skill is a directory under `.claude/
 
 | Skill | Purpose |
 |-------|---------|
+| `/prd` | Interview user about greenfield project, produce PRD + backlog + agent context file |
 | `/brainstorm` | Divergent design exploration: multi-option proposals, trade-offs, design approval before `/plan` |
-| `/plan` | Interview user, write spec, create task breakdown in `tasks/todo.md` |
+| `/plan` | Interview user, write spec, create task breakdown in `tasks/todo.md`. Accepts optional backlog item argument |
 | `/build` | Autonomous orchestrator: TDD + sub-agents + 2-stage review + parallel dispatch + simplify + spec validation |
 | `/debug` | Investigate & fix bugs: root cause analysis, architecture questioning, bug register, lessons, `/loop` test verification |
 | `/tdd` | Execute TDD loop for tasks in `tasks/todo.md` (manual, with user checkpoints) |
@@ -156,12 +164,15 @@ Before marking any task complete, confirm:
 ## Key Directories
 
 ```
-.claude/agents/     → Specialized subagents (invoked via Agent tool)
-.claude/skills/     → Skills invokable with /skill-name
-.claude/hooks/      → Lifecycle automation scripts
-tasks/todo.md       → Active task plan (single source of truth)
-tasks/bugs.md       → Bug register (opened/fixed per session)
-tasks/lessons.md    → Self-improvement patterns
-tasks/checkpoint.md → Session snapshots
-specs/              → Feature specifications
+.claude/agents/            → Specialized subagents (invoked via Agent tool)
+.claude/skills/            → Skills invokable with /skill-name
+.claude/hooks/             → Lifecycle automation scripts
+specs/                     → Feature specifications
+specs/prd-<name>.md        → Product Requirements Document (from /prd)
+tasks/backlog.md           → Ordered work items by phase (from /prd)
+tasks/project-context.md   → Compressed agent briefing (auto-generated, do not edit manually)
+tasks/todo.md              → Active task plan for current feature (from /plan)
+tasks/bugs.md              → Bug register (opened/fixed per session)
+tasks/lessons.md           → Self-improvement patterns
+tasks/checkpoint.md        → Session snapshots
 ```

--- a/specs/prd-skill.md
+++ b/specs/prd-skill.md
@@ -1,0 +1,243 @@
+# Spec: /prd Skill — Product Requirements Document Generator
+
+## Behavior
+
+A new `/prd` skill that interviews the user about a greenfield project, produces a structured PRD document, and decomposes it into an ordered backlog. Also generates a compressed project-context file for agent consumption.
+
+This skill fills the gap between "I have a project idea" and "I have a backlog of work items to plan and build." It is the entry point for greenfield projects.
+
+## Flow Integration
+
+```
+GREENFIELD:   /prd → specs/prd-<name>.md + tasks/backlog.md + tasks/project-context.md
+              → pick item → /plan (spec + TDD tasks) → /build → mark backlog item done
+
+EXISTING:     tasks/backlog.md already exists
+              → pick item → /plan → /build → mark done
+```
+
+### Skill Interactions
+
+- **`/brainstorm`**: Use *before* `/prd` when the project idea itself is unclear and needs divergent exploration. `/prd` assumes you know what you want to build.
+- **`/plan`**: Updated to optionally accept a backlog item argument. Reads `tasks/project-context.md` for broader project context when writing a spec. Works independently when no backlog exists.
+- **`/build`**: Updated with role-based context injection — reads `tasks/project-context.md` and passes relevant sections to each sub-agent type.
+
+## Inputs
+
+- User's project idea (via argument or interview)
+- Existing codebase context (if any — package.json, directory layout, CLAUDE.md)
+- User answers to interview questions
+
+## Outputs
+
+| File | Purpose | Audience |
+|------|---------|----------|
+| `specs/prd-<name>.md` | Full PRD document | Humans + planning agents |
+| `tasks/backlog.md` | Ordered work items grouped by phase | Humans + `/plan` |
+| `tasks/project-context.md` | Compressed, section-labeled agent briefing | Sub-agents only |
+
+## PRD Document Structure
+
+The PRD balances traditional product requirements (sections 1-8) with agent-optimization (sections 9-11).
+
+### Section 1: Overview
+- Project name and one-line description
+- Problem statement: what pain exists today
+- Vision: what the world looks like after this is built
+- Target users / personas (brief — name, role, key need)
+
+### Section 2: Goals & Success Criteria
+- 3-5 measurable project goals
+- Definition of "done" for the overall project
+- Key metrics or outcomes that indicate success
+
+### Section 3: User Stories
+- Grouped by feature area / persona
+- Format: `As [persona], I want [action], so that [benefit]`
+- Priority: Must-have / Should-have / Nice-to-have (MoSCoW)
+
+### Section 4: Functional Requirements
+- Organized by module or feature area
+- Each requirement has:
+  - Description (what it does)
+  - Acceptance criteria using EARS notation: `WHEN [condition] THE SYSTEM SHALL [behavior]`
+  - Priority (Must / Should / Nice)
+
+### Section 5: Non-Functional Requirements
+- Performance targets (response times, throughput)
+- Security requirements (auth, data protection, compliance)
+- Scalability expectations
+- Accessibility standards
+- Browser/device/platform support
+
+### Section 6: Technical Architecture
+- Tech stack (languages, frameworks, databases, infra)
+- System boundaries and integrations
+- Data model overview (key entities and relationships)
+- Key architectural decisions and rationale
+
+### Section 7: Out of Scope / Non-Goals
+- Explicit list of what this project does NOT include
+- Things that might seem implied but are deliberately excluded
+- Future considerations parked for later
+
+### Section 8: Dependencies & Assumptions
+- External services, APIs, third-party tools
+- Team/resource assumptions
+- Technical assumptions (e.g., "users have modern browsers")
+
+### Section 9: Phases & Dependency Order
+- Ordered phases, each ending in something verifiable
+- Each phase lists which functional requirements it addresses
+- Explicit dependencies: "Phase 2 requires Phase 1's API endpoints"
+- Phase sizing: each phase should be 1-3 specs worth of work
+
+### Section 10: Protection List
+- Files, systems, or patterns that must NOT be modified
+- Existing functionality that must be preserved
+- External contracts or APIs that cannot change
+
+### Section 11: Risks & Mitigations
+- Technical risks (new technology, complex integrations)
+- Scope risks (requirements likely to change)
+- Mitigation strategy for each
+
+## Backlog Structure (`tasks/backlog.md`)
+
+```markdown
+# Backlog: [Project Name]
+> PRD: specs/prd-<name>.md
+> Generated: YYYY-MM-DD
+
+## Phase 1: [Phase Name]
+> Dependencies: none
+> Verifiable outcome: [what you can demo/test when phase is done]
+
+- [ ] [Feature/module name] — [one-line description]
+- [ ] [Feature/module name] — [one-line description]
+
+## Phase 2: [Phase Name]
+> Dependencies: Phase 1
+> Verifiable outcome: [what you can demo/test when phase is done]
+
+- [ ] [Feature/module name] — [one-line description]
+- [ ] [Feature/module name] — [one-line description]
+```
+
+Each backlog item is "spec-sized" — big enough to need `/plan` but small enough to be one coherent feature. Target: 3-8 items per phase, 2-5 phases per project.
+
+## Project Context Structure (`tasks/project-context.md`)
+
+Compressed, section-labeled file for selective agent injection.
+
+```markdown
+# Project Context: [Project Name]
+> Source PRD: specs/prd-<name>.md
+> Generated: YYYY-MM-DD — regenerate with /prd if PRD changes
+
+## [ARCHITECTURE]
+Tech stack, system boundaries, data model overview.
+Kept concise — no rationale, just facts.
+
+## [PROTECTION]
+Files and systems that must not be modified.
+
+## [NON-FUNCTIONAL]
+Performance, security, scalability, accessibility targets.
+
+## [CURRENT-PHASE]
+Which phase is active, what's been completed, what's next.
+
+## [CONVENTIONS]
+Naming conventions, patterns, coding standards specific to this project.
+```
+
+### Role-Based Context Injection
+
+`/build` uses these sections selectively when delegating to sub-agents:
+
+| Agent Type | Sections Injected |
+|---|---|
+| Backend/Frontend developer | `[ARCHITECTURE]` + `[PROTECTION]` + relevant functional requirements from spec |
+| Code reviewer | Feature spec + coding standards only — no project-context needed |
+| Code debugger | Failing test + relevant code only — no project-context needed |
+| Security reviewer | `[ARCHITECTURE]` + `[NON-FUNCTIONAL]` (security subsection) |
+| Planner (`/plan`) | Full PRD + backlog item (reads PRD directly, not compressed context) |
+
+## The /prd Process
+
+### Step 1 — Explore Existing Context
+- Read codebase structure if any exists
+- Read `.claude/memory.md` for prior decisions
+- Check if a PRD or backlog already exists (offer to update vs. create new)
+
+### Step 2 — Hybrid Draft + Interview
+- From the user's initial prompt, draft a skeleton PRD covering as many sections as possible
+- Identify gaps — sections where information is missing or ambiguous
+- Interview the user on the gaps only, one question at a time
+- Prefer multiple-choice questions when possible
+
+### Step 3 — Write the PRD
+- Write `specs/prd-<name>.md` with all 11 sections
+- Self-review before presenting:
+  - No placeholders or "TBD" items
+  - All acceptance criteria are boolean-testable (EARS notation)
+  - Non-goals section is populated (not empty)
+  - Phases have clear dependency ordering
+  - Protection list is populated (even if minimal)
+
+### Step 4 — User Review
+- Present the full PRD
+- Ask: "Does this PRD capture your requirements? I can adjust any section. Confirm with 'y' to generate the backlog."
+- Iterate on feedback until approved
+
+### Step 5 — Generate Backlog
+- Decompose the PRD into `tasks/backlog.md`
+- Each phase from Section 9 becomes a phase in the backlog
+- Each functional requirement cluster becomes a backlog item
+- Order respects dependency chain
+
+### Step 6 — Generate Project Context
+- Compress the PRD into `tasks/project-context.md`
+- Strip rationale, keep facts
+- Label sections for selective extraction
+
+### Step 7 — Present Summary
+Show the user:
+- PRD location
+- Backlog with item count per phase
+- Suggested first item to `/plan`
+
+## Changes to Existing Skills
+
+### `/plan` SKILL.md Changes
+1. Accept optional argument: `/plan <backlog-item-name>`
+2. Pre-flight: check for `tasks/project-context.md` — if exists, read it for broader context
+3. Pre-flight: check for `tasks/backlog.md` — if exists and argument provided, validate the item exists
+4. When planning a backlog item: mark it as `[~]` (in progress) in `tasks/backlog.md`
+5. When planning without a backlog: behave as today (interview from scratch)
+
+### `/build` SKILL.md Changes
+1. Pre-flight: check for `tasks/project-context.md` — if exists, load it
+2. When delegating to sub-agents: inject context sections based on agent role (see table above)
+3. After completing all tasks for a feature: if `tasks/backlog.md` exists, mark the corresponding item as `[x]`
+
+## Edge Cases
+- **Multiple PRDs**: A project should have one PRD. If `/prd` finds an existing PRD, ask: "Update existing PRD or create a new one?"
+- **PRD changes after backlog exists**: Warn user that backlog may be stale. Offer to regenerate backlog (preserving `[x]` items).
+- **No backlog item matches `/plan` argument**: List available items and ask user to pick one.
+- **Empty protection list**: Acceptable for greenfield. Note: "No protected files — greenfield project."
+- **Massive project**: If the interview reveals >5 phases or >30 backlog items, suggest splitting into multiple PRDs or explicitly calling out an MVP phase.
+
+## Acceptance Criteria
+- [ ] `/prd` skill file exists at `.claude/skills/prd/SKILL.md`
+- [ ] Running `/prd` with a project idea produces all 3 output files
+- [ ] PRD contains all 11 sections with no TBD placeholders
+- [ ] Backlog items are ordered by phase with dependency annotations
+- [ ] Project context file has labeled sections extractable by `/build`
+- [ ] `/plan` reads `tasks/project-context.md` when it exists
+- [ ] `/plan` accepts a backlog item argument and marks it `[~]` in backlog
+- [ ] `/build` injects role-appropriate context sections into sub-agent prompts
+- [ ] `/build` marks backlog items `[x]` on completion
+- [ ] Existing `/plan` behavior (no backlog) is unchanged
+- [ ] CLAUDE.md updated with `/prd` skill and new file locations

--- a/specs/prd-skill.md
+++ b/specs/prd-skill.md
@@ -222,6 +222,51 @@ Show the user:
 2. When delegating to sub-agents: inject context sections based on agent role (see table above)
 3. After completing all tasks for a feature: if `tasks/backlog.md` exists, mark the corresponding item as `[x]`
 
+## Living Document — Divergence Detection & Updates
+
+The PRD and project-context are living documents that evolve as the project is built. Two mechanisms keep them in sync with reality.
+
+### Rule: `project-context.md` can be auto-updated. `specs/prd-*.md` requires user confirmation.
+
+### Divergence Check in `/plan`
+
+After writing a spec for a backlog item, `/plan` compares key decisions against `tasks/project-context.md`:
+- New dependencies or libraries not in the architecture section
+- Data model changes (new entities, changed relationships)
+- Contradictions with stated technical architecture
+- New non-functional requirements (e.g., "this feature needs WebSocket support")
+
+If divergence is detected, prompt the user:
+> "This spec introduces [specific change]. Update the PRD and project context? (y/n)"
+
+If yes:
+1. Update only the affected sections in `specs/prd-<name>.md`
+2. Regenerate `tasks/project-context.md` from the updated PRD
+3. Log the change in the PRD's revision history
+
+### Staleness Check in `/wrap-up-session`
+
+Before committing, `/wrap-up-session` performs a quick diff:
+- Compare `package.json` / `pyproject.toml` dependencies against `[ARCHITECTURE]`
+- Check for new directories or modules not reflected in context
+- Look for pattern changes (new middleware, changed auth approach)
+
+If divergence found:
+- Auto-update `tasks/project-context.md` (agent-facing, no approval needed)
+- Flag PRD sections that may need updating and ask user for confirmation
+
+### PRD Revision History
+
+Append to the bottom of the PRD when updated:
+
+```markdown
+## Revision History
+| Date | Section | Change | Trigger |
+|------|---------|--------|---------|
+| YYYY-MM-DD | Technical Architecture | Added Redis for caching | /plan: caching-layer spec |
+| YYYY-MM-DD | Non-Functional | Added WebSocket requirement | /plan: real-time-updates spec |
+```
+
 ## Edge Cases
 - **Multiple PRDs**: A project should have one PRD. If `/prd` finds an existing PRD, ask: "Update existing PRD or create a new one?"
 - **PRD changes after backlog exists**: Warn user that backlog may be stale. Offer to regenerate backlog (preserving `[x]` items).
@@ -240,4 +285,8 @@ Show the user:
 - [ ] `/build` injects role-appropriate context sections into sub-agent prompts
 - [ ] `/build` marks backlog items `[x]` on completion
 - [ ] Existing `/plan` behavior (no backlog) is unchanged
+- [ ] `/plan` performs divergence check against project-context after writing spec
+- [ ] `/wrap-up-session` performs staleness check against project-context before commit
+- [ ] PRD includes revision history section, updated on changes
+- [ ] `project-context.md` can be auto-updated; PRD changes require user confirmation
 - [ ] CLAUDE.md updated with `/prd` skill and new file locations


### PR DESCRIPTION
## Summary

- **New `/prd` skill** — interviews the user about a greenfield project and produces three artifacts:
  - `specs/prd-<name>.md` — full PRD with 11 sections (traditional requirements + agent-optimization layer)
  - `tasks/backlog.md` — ordered work items grouped by phase with dependency annotations
  - `tasks/project-context.md` — compressed, section-labeled briefing for selective agent injection
- **Updated `/plan`** — accepts optional backlog item argument, reads project-context for broader context, performs divergence check after writing specs to keep PRD in sync
- **Updated `/build`** — role-based context injection (developers get architecture + protection, reviewers get spec only, debuggers get nothing extra), marks backlog items complete after build
- **Updated `/wrap-up-session`** — staleness check on project-context.md before commit, auto-updates agent context, flags stale PRD sections for user review
- **Updated `CLAUDE.md`** — added PRD workflow step, new skill to table, backlog/project-context to key directories

## Design decisions

- PRD sections 1-8 are traditional product requirements (for humans). Sections 9-11 are the agent-optimization layer (phases, protection list, risks)
- Acceptance criteria use EARS notation (`WHEN x THE SYSTEM SHALL y`) for boolean testability
- `project-context.md` can be auto-updated by agents. PRD changes always require user confirmation
- Backlog status: `[ ]` not started, `[~]` in progress, `[x]` done
- Design spec at `specs/prd-skill.md`

## Test plan

- [ ] Run `/prd` with a project idea and verify all 3 output files are generated
- [ ] Run `/plan <backlog-item>` and verify it reads project-context and marks item `[~]`
- [ ] Run `/plan` without backlog and verify existing behavior is unchanged
- [ ] Run `/build` and verify role-based context injection in sub-agent prompts
- [ ] Run `/wrap-up-session` and verify staleness check on project-context.md

https://claude.ai/code/session_01MSuzTJDpW2Q12gk513VJkn