### PR TITLE
Add disable-model-invocation: false to all skill frontmatter

### DIFF
--- a/.claude/skills/brainstorm/SKILL.md
+++ b/.claude/skills/brainstorm/SKILL.md
@@ -2,6 +2,7 @@
 name: brainstorm
 description: Explore a feature idea through divergent design thinking before committing to a spec. Use before /plan for non-trivial features requiring design decisions.
 argument-hint: "[feature idea or problem statement]"
+disable-model-invocation: false
 ---
 
 # /brainstorm — Divergent Design Exploration

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: build
 description: Execute the task plan from tasks/todo.md autonomously using TDD with sub-agent delegation. Use after /plan is confirmed.
+disable-model-invocation: false
 ---
 
 # /build — Autonomous Build Orchestrator

--- a/.claude/skills/checkpoint/SKILL.md
+++ b/.claude/skills/checkpoint/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: checkpoint
 description: Snapshot current session progress to tasks/checkpoint.md for handoff or pause.
+disable-model-invocation: false
 ---
 
 # /checkpoint — Session Checkpoint

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -2,6 +2,7 @@
 name: debug
 description: Systematically investigate, diagnose, and fix bugs using root cause analysis. Use when debugging errors, test failures, runtime issues, or when the user reports a bug. Integrates with bug register, lessons learned, and memory.
 argument-hint: "[bug description or error message]"
+disable-model-invocation: false
 ---
 
 # /debug — Bug Investigation & Fix

--- a/.claude/skills/folder-context-optimization/SKILL.md
+++ b/.claude/skills/folder-context-optimization/SKILL.md
@@ -2,6 +2,7 @@
 name: folder-context-optimization
 description: Sweep a folder to identify legacy/unused files, propose archival, and update docs. Use when a directory feels bloated or disorganized.
 argument-hint: "<folder-path>"
+disable-model-invocation: false
 ---
 
 # /folder-context-optimization — Context Sweep

--- a/.claude/skills/learn/SKILL.md
+++ b/.claude/skills/learn/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: learn
 description: Extract durable patterns from the current session and persist to memory.md and lessons.md.
+disable-model-invocation: false
 ---
 
 # /learn — Capture Session Learnings

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -2,6 +2,7 @@
 name: plan
 description: Interview user, write a feature spec, and create a TDD task breakdown. Use for any non-trivial feature before coding.
 argument-hint: "[feature description]"
+disable-model-invocation: false
 ---
 
 # /plan — Structured Spec + Plan Mode

--- a/.claude/skills/prd/SKILL.md
+++ b/.claude/skills/prd/SKILL.md
@@ -2,6 +2,7 @@
 name: prd
 description: Interview the user about a greenfield project, produce a structured PRD, ordered backlog, and agent context file. Use as the entry point for new projects.
 argument-hint: "[project idea or description]"
+disable-model-invocation: false
 ---
 
 # /prd — Product Requirements Document Generator

--- a/.claude/skills/receive-review/SKILL.md
+++ b/.claude/skills/receive-review/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: receive-review
 description: Process incoming code review feedback with technical rigor. Use when receiving review comments on PRs, from users, or from automated review tools.
+disable-model-invocation: false
 ---
 
 # /receive-review — Processing Code Review Feedback

--- a/.claude/skills/security-scan/SKILL.md
+++ b/.claude/skills/security-scan/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: security-scan
 description: OWASP-focused security audit on recently changed files. Use after code changes to check for vulnerabilities.
+disable-model-invocation: false
 ---
 
 # /security-scan — Security Review

--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -2,6 +2,7 @@
 name: simplify
 description: Review changed code for reuse, clean code, and SOLID violations, then fix issues found.
 argument-hint: "[optional file path]"
+disable-model-invocation: false
 ---
 
 # /simplify — Code Simplification Review

--- a/.claude/skills/start-qa/SKILL.md
+++ b/.claude/skills/start-qa/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: start-qa
 description: Discover project config, restart app, and launch browser for manual QA testing.
+disable-model-invocation: false
 ---
 
 # /start-qa — Start QA Session

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: sync
 description: Pull latest skills, hooks, agents, and config from the coding-agent-workflow template repo.
+disable-model-invocation: false
 ---
 
 # /sync — Sync Workflow Updates from Template Repo

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: tdd
 description: Execute TDD loop for tasks in tasks/todo.md with user checkpoints between steps.
+disable-model-invocation: false
 ---
 
 # /tdd — TDD Workflow

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: verify
 description: Enforce evidence-based verification before any completion claims. Use before committing, creating PRs, marking tasks done, or claiming success.
+disable-model-invocation: false
 ---
 
 # /verify — Verification Before Completion

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: wrap-up-session
 description: Close session with parallel code review, testing, fixes, and a clean commit. Use at the end of any coding session.
+disable-model-invocation: false
 ---
 
 # /wrap-up-session — Session Wrap-Up

--- a/.claude/skills/writing-skills/SKILL.md
+++ b/.claude/skills/writing-skills/SKILL.md
@@ -2,6 +2,7 @@
 name: writing-skills
 description: Author new skills with proper structure, iron laws, and reference docs. Use when creating or improving skills for the workflow.
 argument-hint: "[skill name or purpose]"
+disable-model-invocation: false
 ---
 
 # /writing-skills — Skill Authoring Guide
@@ -30,10 +31,11 @@ Every skill lives in `.claude/skills/<skill-name>/SKILL.md`:
 name: skill-name                    # Kebab-case, matches directory name
 description: One-line purpose.      # When to invoke this skill
 argument-hint: "[what to pass]"     # Optional — shown in help
+disable-model-invocation: false     # REQUIRED — must be false or skill won't work via Skill tool
 ---
 ```
 
-> **Note**: Do NOT use `disable-model-invocation: true` — it blocks the Skill tool from invoking the skill entirely. All skills run in the main context by default.
+> **CRITICAL**: Always include `disable-model-invocation: false` in frontmatter. If set to `true` (or omitted in some environments), the Skill tool cannot invoke the skill, causing "Error: Skill X cannot be used with Skill tool due to disable-model-invocation".
 
 ### Markdown Body
 


### PR DESCRIPTION
## Summary
Adds the required `disable-model-invocation: false` field to the frontmatter of all skill definitions across the workflow. This ensures that all skills can be properly invoked by the Skill tool.

## Changes
- Added `disable-model-invocation: false` to 17 skill SKILL.md files:
  - writing-skills
  - brainstorm
  - build
  - checkpoint
  - debug
  - folder-context-optimization
  - learn
  - plan
  - prd
  - receive-review
  - security-scan
  - simplify
  - start-qa
  - sync
  - tdd
  - verify
  - wrap-up-session

- Updated the writing-skills SKILL.md documentation to clarify that `disable-model-invocation: false` is **REQUIRED** in all skill frontmatter, with a critical note explaining that omitting it or setting it to `true` will cause "Error: Skill X cannot be used with Skill tool" failures.

## Implementation Details
The `disable-model-invocation: false` field is a required configuration that explicitly enables skill invocation through the Skill tool. Without this field (or if set to `true`), the Skill tool cannot invoke the skill, resulting in runtime errors. This change ensures consistency across all skills and prevents invocation failures in environments where the field defaults to `true` or is strictly required.

https://claude.ai/code/session_01GeFaPuCPa5JrPW5H3pPPXC