### PR TITLE
Add deployment verification system with service-agnostic adapters

### DIFF
--- a/.claude/deployments/README.md
+++ b/.claude/deployments/README.md
@@ -1,0 +1,139 @@
+# Deployment Adapters
+
+> Adapter contract for `/verify-deployment`. Each file in this directory describes one deployment service. Adding a new service = drop in a new `<service>.md` file. No changes to skills or hooks required.
+
+This directory is read by:
+
+- **`/verify-deployment`** — loads the runbook for each row in `CLAUDE.md` § Deployment Targets, validates frontmatter against this contract, then drives the wait/log/fix loop.
+- **`/setup-deployment`** — scans every runbook's `detect_files` to figure out which services this project uses, then writes the routing table into `CLAUDE.md`.
+- **`.claude/hooks/session-start.sh`** — uses `detect_files` to print a one-line nudge when signal files exist but no Deployment Targets section is configured.
+
+The frontmatter is the **machine-readable contract**. The body is **human-readable troubleshooting notes** that get fed to the `code-debugger` agent on failure.
+
+---
+
+## Frontmatter Contract
+
+### Required fields (always)
+
+| Field | Type | Description |
+|---|---|---|
+| `name` | string | Lowercase identifier. Must match the filename (`railway.md` → `name: railway`). Used internally as a stable key. |
+| `display_name` | string | Human-readable name for reports and the Done banner (e.g. `Railway`, `Vercel`, `Fly.io`). |
+| `detect_files` | list[string] | Files or directories at the project root whose presence signals this service is in use. Any single match is sufficient. Trailing `/` indicates a directory. |
+| `status_source` | enum | Either `github-checks` or `cli`. Determines how `/verify-deployment` polls for build status. |
+| `auth_check_command` | string | A shell command that exits 0 when credentials are present and valid. Run **once before polling** so we fail fast instead of waiting on a build we can't read. |
+| `dashboard_url_template` | string | URL template for the service's dashboard. Supports `{project_id}` interpolation from the CLAUDE.md table. Used in escalation messages and the deploy report. |
+| `default_timeout_minutes` | integer | Maximum wait time per build attempt before declaring TIMEOUT. Overridable from `CLAUDE.md` config block. |
+
+### Required when `status_source: github-checks`
+
+| Field | Type | Description |
+|---|---|---|
+| `check_contexts` | list[string] | GitHub check run names this service publishes against the commit SHA. `/verify-deployment` matches against this list when calling `mcp__github__get_commit`. **All** matching contexts must resolve to success. |
+
+### Required when `status_source: cli`
+
+| Field | Type | Description |
+|---|---|---|
+| `cli_status_command` | string | Shell command that returns the latest deployment status for the current commit SHA. Should be JSON-friendly when possible — `/verify-deployment` parses `state` / `status` fields. |
+
+### Optional (always)
+
+| Field | Type | Description |
+|---|---|---|
+| `log_fetch_command` | string | Shell command template that fetches build logs. Supports `{deployment_id}` interpolation. Used as a fallback for `github-checks` mode when the check run details URL doesn't expose full logs, and as the primary log source for `cli` mode. |
+| `common_failure_patterns` | list[object] | Substring patterns paired with hints. When a pattern matches the fetched logs, the hint is added to the `code-debugger` agent's context. See format below. |
+
+### `common_failure_patterns` format
+
+```yaml
+common_failure_patterns:
+  - match: "npm ERR! peer dep"
+    hint: "Peer dependency mismatch — check package.json versions"
+  - match: "Nixpacks build failed"
+    hint: "Check the buildCommand field in railway.json"
+```
+
+- `match` is a literal substring (not a regex). Case-sensitive.
+- `hint` is a one-line actionable suggestion that becomes part of the debugger's context window.
+- Multiple patterns can match the same log; all matching hints are passed through.
+- Optional. Omit the field entirely if you have no curated failure modes for this service.
+
+---
+
+## Contract Validation
+
+`/verify-deployment` validates each runbook on read. A runbook is **invalid** if:
+
+- Any required field is missing
+- `status_source` is neither `github-checks` nor `cli`
+- `status_source: github-checks` and `check_contexts` is missing or empty
+- `status_source: cli` and `cli_status_command` is missing
+- `name` does not match the filename stem (`railway.md` → `name: railway`)
+- `common_failure_patterns` is present but any entry lacks both `match` and `hint`
+
+**On invalid runbook**: `/verify-deployment` skips that target with a clear report (e.g. `"railway: malformed runbook — missing required field 'check_contexts'"`) and continues with other targets. **Never crashes the whole verification.**
+
+---
+
+## Worked Example
+
+```yaml
+---
+name: railway
+display_name: Railway
+detect_files:
+  - railway.json
+  - railway.toml
+  - .railway/
+status_source: github-checks
+check_contexts:
+  - Railway
+  - railway/deployment
+auth_check_command: railway whoami
+log_fetch_command: railway logs --deployment {deployment_id}
+dashboard_url_template: https://railway.app/project/{project_id}
+default_timeout_minutes: 15
+common_failure_patterns:
+  - match: "npm ERR! peer dep"
+    hint: "Peer dependency mismatch — check package.json versions"
+  - match: "Nixpacks build failed"
+    hint: "Check the buildCommand field in railway.json"
+  - match: "ECONNREFUSED"
+    hint: "Service tried to connect during build — check for top-level await on a network resource"
+---
+
+# Railway Deployment Runbook
+
+## Manual troubleshooting
+
+When the agent gives up after 3 iterations, check the dashboard for:
+
+1. **Environment variables** — missing or stale env vars are not visible in build logs but break runtime
+2. **Service dependencies** — Railway only rebuilds the service whose code changed; check sibling services
+3. **Build vs deploy logs** — compilation can pass and the container still fail to start
+```
+
+---
+
+## How to Add a New Service
+
+1. **Create `.claude/deployments/<service>.md`** with the frontmatter contract above
+2. **Pick a `status_source`**:
+   - **`github-checks`** if the service publishes commit check runs to GitHub (Railway, Vercel, Netlify, Render — most modern PaaS). This is the preferred path: it requires no extra auth beyond the existing GitHub MCP and works for any check-publishing service.
+   - **`cli`** if the service has a CLI that can report deployment status by commit SHA but doesn't integrate with GitHub Checks (Fly.io's standard flow, self-hosted services, internal platforms).
+3. **Discover the GitHub check context names** by running a deploy and inspecting the commit on github.com — the check names you see there go into `check_contexts`.
+4. **Write the `auth_check_command`** to exit 0 only when credentials are present (e.g. `railway whoami`, `vercel whoami`, `flyctl auth whoami`). This runs before polling so we fail fast.
+5. **Add 2–4 `common_failure_patterns`** for the most frequent build failures you've personally hit on this service. These compound across teams that `/sync` from this template — better hints lead to faster fix loops.
+6. **Write a `## Manual troubleshooting` body** with the things the agent can't auto-diagnose: env var issues, quota limits, dashboard-only settings.
+7. **Test the runbook** by adding a row to your project's `CLAUDE.md` § Deployment Targets that points at it, then run `/verify-deployment` after a known-good push.
+8. **Open a PR back to the template** — once your runbook works for your project, others using `/sync` will benefit.
+
+---
+
+## Contract Stability
+
+The frontmatter schema is the contract between runbooks and `/verify-deployment`. Adding new optional fields is non-breaking. Renaming or removing fields is breaking and requires updating every runbook in this directory plus the validation logic in `/verify-deployment`.
+
+If you need a field that doesn't exist yet, add it as **optional** first, ship runbooks that use it, then promote it to required only when every starter runbook in this directory has been updated.

--- a/.claude/deployments/README.md
+++ b/.claude/deployments/README.md
@@ -2,6 +2,8 @@
 
 > Adapter contract for `/verify-deployment`. Each file in this directory describes one deployment service. Adding a new service = drop in a new `<service>.md` file. No changes to skills or hooks required.
 
+**Scope note**: "Deployment" is used loosely here. Anything that publishes a commit check run to GitHub after a push is a valid adapter — CI pipelines (GitHub Actions, CircleCI), lint/typecheck workflows, security scans, and literal deploy pipelines (Railway, Vercel, Netlify, Fly.io) all fit the same pattern at the GitHub Checks API layer. The directory name stays `deployments/` because it's the common word for "stuff that happens post-push" even though not every adapter is a true deploy.
+
 This directory is read by:
 
 - **`/verify-deployment`** — loads the runbook for each row in `CLAUDE.md` § Deployment Targets, validates frontmatter against this contract, then drives the wait/log/fix loop.

--- a/.claude/deployments/github-actions.md
+++ b/.claude/deployments/github-actions.md
@@ -1,0 +1,86 @@
+---
+name: github-actions
+display_name: GitHub Actions
+detect_files:
+  - .github/workflows/
+status_source: github-checks
+check_contexts:
+  # Customize per project — these are sensible defaults for many repos but
+  # the actual check run names come from your workflow `jobs.<id>.name` or
+  # fallback to the job key. Inspect a recent commit on github.com to see
+  # the exact context strings to put here.
+  - test
+  - lint
+  - typecheck
+  - build
+auth_check_command: "true"
+log_fetch_command: gh run view {deployment_id} --log-failed
+dashboard_url_template: https://github.com/{project_id}/actions
+default_timeout_minutes: 10
+common_failure_patterns:
+  - match: "Process completed with exit code 1"
+    hint: "Generic job failure — scan earlier log lines for the actual error message; the exit-code line is almost always just the final symptom"
+  - match: "npm ERR! Test failed"
+    hint: "Unit tests failed in CI. Run `npm test` locally with the same Node version pinned in engines.node or .nvmrc to reproduce"
+  - match: "Type error:"
+    hint: "TypeScript check failed. Run `tsc --noEmit` locally; most common cause is a missing type import or a strict-mode difference with the CI tsconfig"
+  - match: "ESLint found"
+    hint: "Lint check failed. Run `npm run lint` locally and fix reported violations; do not disable rules to pass CI"
+  - match: "Cannot find module"
+    hint: "Dependency missing in CI. Verify the package is in dependencies (not devDependencies if the build step needs it) and the lockfile is committed"
+  - match: "No space left on device"
+    hint: "CI runner exhausted disk. Check for a runaway cache step or a build that writes to /tmp without cleanup; this is an infra issue, not a code bug"
+  - match: "The job running on runner .* has exceeded the maximum execution time"
+    hint: "Job hit GitHub Actions' 6-hour timeout (or a shorter timeout-minutes setting). Profile locally and look for hanging post-install scripts or infinite loops"
+---
+
+# GitHub Actions Runbook
+
+GitHub Actions publishes commit check runs under the job name (or `jobs.<id>.name` if set). `/verify-deployment` polls these via the GitHub Checks API, so no separate auth is needed beyond the existing GitHub MCP access.
+
+## Auth check is a no-op
+
+The `auth_check_command: "true"` field is intentional. Unlike Railway or Vercel runbooks — which need a CLI session to fetch logs on failure — GitHub Actions logs are reachable via two GitHub-native paths:
+
+1. **Primary**: the check run's `details_url` from `mcp__github__get_commit`, fetched via web fetch
+2. **Fallback**: `gh run view --log-failed` if the `gh` CLI is installed locally (not required)
+
+If neither is available in your environment, `/verify-deployment` will still detect the failure via the check run's `conclusion` field — you just won't get rich log hints fed to the debugger. That's a graceful degradation, not a crash.
+
+## `check_contexts` must be customized
+
+The shipped defaults (`test`, `lint`, `typecheck`, `build`) work for many Node/TS projects but your workflow may use different job names. To find the exact strings:
+
+1. Open a recent commit on github.com
+2. Scroll to the "All checks have passed/failed" section
+3. The exact names shown there are what `check_contexts` needs to match
+
+Common project-specific variations you'll want to rename:
+
+- `test (ubuntu-latest, 18.x)` — matrix jobs include the matrix values in the name
+- `ci / test` — if the job is inside a named workflow, it's prefixed with the workflow name
+- Custom job names like `Unit Tests`, `Integration Tests`, `E2E`
+
+Run `/setup-deployment` after editing `check_contexts` to re-validate the runbook against the routing table.
+
+## Dashboard URL
+
+The `dashboard_url_template` interpolates `{project_id}` from the `Project ID` column of `CLAUDE.md` § Deployment Targets. For GitHub Actions, use `<owner>/<repo>` (e.g. `joaovsales/coding-agent-workflow`). The resulting URL opens the Actions tab for the repo.
+
+## Manual troubleshooting
+
+When `/verify-deployment` exhausts its 3 fix iterations and escalates, walk this list:
+
+1. **Flaky tests** — re-run the workflow manually from the Actions tab. If it passes on retry without any code change, the test is flaky and should be quarantined in a separate PR, not patched by the fix loop.
+2. **Secrets and environment variables** — a job that runs locally but fails in CI almost always means a secret or env var is missing from the repo's Actions secrets. Check Settings → Secrets and variables → Actions.
+3. **Matrix failures** — if only one matrix entry fails (e.g. `test (windows-latest)` fails but `test (ubuntu-latest)` passes), the issue is OS-specific. The fix loop can't reproduce this locally without the matching OS.
+4. **Runner image drift** — GitHub occasionally updates `ubuntu-latest` or `macos-latest` images, which can silently break builds. Pin to a specific image tag (e.g. `ubuntu-22.04`) if this is a recurring problem.
+5. **Required status checks vs advisory** — some jobs are marked as required in branch protection rules. Failing a required check blocks merge; a failing advisory check does not. `/verify-deployment` treats all failures equally — the user decides post-escalation whether the failing check was required.
+
+## CI is typically fast
+
+`default_timeout_minutes: 10` — CI jobs that take longer than 10 minutes are unusual and usually mean something is wrong. If your workflow genuinely needs longer (large test matrix, slow integration tests), override in `CLAUDE.md` § Deployment Targets → `**Config:**` → `Build timeout: 20m`.
+
+## Adapter contract note
+
+This runbook is a "post-push check" in the loose sense — GitHub Actions isn't literally a deployment, but at the GitHub Checks API layer it's indistinguishable from Railway or Vercel. The `.claude/deployments/` directory holds adapters for any post-push check run, including CI, lint, security scans, and deploy pipelines. See `.claude/deployments/README.md` for the full contract.

--- a/.claude/deployments/railway.md
+++ b/.claude/deployments/railway.md
@@ -1,0 +1,56 @@
+---
+name: railway
+display_name: Railway
+detect_files:
+  - railway.json
+  - railway.toml
+  - .railway/
+status_source: github-checks
+check_contexts:
+  - Railway
+  - railway/deployment
+auth_check_command: railway whoami
+cli_status_command: railway status --json
+log_fetch_command: railway logs --deployment {deployment_id}
+dashboard_url_template: https://railway.app/project/{project_id}
+default_timeout_minutes: 15
+common_failure_patterns:
+  - match: "npm ERR! peer dep"
+    hint: "Peer dependency mismatch — check package.json versions and consider running `npm install --legacy-peer-deps` locally to reproduce"
+  - match: "Nixpacks build failed"
+    hint: "Nixpacks couldn't infer the build steps — set `build.builder` and `build.buildCommand` explicitly in railway.json"
+  - match: "ECONNREFUSED"
+    hint: "Build code tried to reach a network service. Check for top-level `await` on a database/HTTP call running at import time"
+  - match: "Module not found"
+    hint: "Missing dependency or stale lockfile. Verify the package is in dependencies (not devDependencies) and the lockfile is committed"
+  - match: "Healthcheck failed"
+    hint: "Container starts but fails Railway's healthcheck — verify `healthcheckPath` in railway.json points at a real route that returns 200 fast"
+---
+
+# Railway Deployment Runbook
+
+Railway publishes commit check runs against the GitHub SHA on every deploy, so the preferred polling path is GitHub Checks. The CLI fields (`cli_status_command`, `log_fetch_command`) are kept as a fallback for projects that disable Railway's GitHub integration.
+
+## Manual troubleshooting
+
+When `/verify-deployment` exhausts its 3 fix iterations and escalates, walk this list:
+
+1. **Environment variables** — missing or stale env vars are not visible in build logs but break runtime healthchecks. Check the Railway dashboard → Variables tab against what the app reads on boot.
+2. **Service dependencies** — Railway only rebuilds the service whose code changed. If your monorepo has sibling services (worker, scheduler, etc.) that share types or schemas, redeploy them too.
+3. **Build vs deploy logs** — compilation can pass and the container can still fail to start. Open the failing deployment in the dashboard and check the **Deploy Logs** tab, not just **Build Logs**.
+4. **Healthcheck path** — the app may serve traffic but the healthcheck route can be wrong, slow, or behind auth. Default expectation: `GET /` returns 200 within 30 seconds of container start.
+5. **Region / volume mounts** — recently moved between regions or attached/detached a volume? Builds succeed but the container can't find its mount point.
+6. **Resource limits** — OOM during build is sometimes silent. Check the deployment's metrics tab for memory spikes near build completion.
+
+## Required setup on the project
+
+For `auth_check_command` to pass locally, the developer running `/verify-deployment` needs either:
+
+- A logged-in Railway CLI session (`railway login` once), **or**
+- `RAILWAY_TOKEN` exported in the shell environment
+
+For the GitHub Checks path to work, the Railway → GitHub integration must be enabled on the repo (Railway dashboard → Project Settings → GitHub).
+
+## Dashboard URL
+
+The `dashboard_url_template` interpolates `{project_id}` from the `Project ID` column of `CLAUDE.md` § Deployment Targets. Example: if the table row says `my-api-prod`, the escalation message will link to `https://railway.app/project/my-api-prod`.

--- a/.claude/deployments/vercel.md
+++ b/.claude/deployments/vercel.md
@@ -1,0 +1,61 @@
+---
+name: vercel
+display_name: Vercel
+detect_files:
+  - vercel.json
+  - .vercel/
+  - .vercelignore
+status_source: github-checks
+check_contexts:
+  - Vercel
+  - Vercel – Preview
+  - Vercel – Production
+auth_check_command: vercel whoami
+cli_status_command: vercel inspect --json
+log_fetch_command: vercel inspect {deployment_id} --logs
+dashboard_url_template: https://vercel.com/{project_id}
+default_timeout_minutes: 15
+common_failure_patterns:
+  - match: "Type error:"
+    hint: "TypeScript compilation failed in the Vercel build. Run `tsc --noEmit` locally with the same Node version Vercel is using to reproduce"
+  - match: "Module not found: Can't resolve"
+    hint: "Import path resolves locally but not in CI. Most common causes: case-sensitive filename mismatch (Linux), missing dependency, or alias not configured in tsconfig paths"
+  - match: "Function exceeds maximum size"
+    hint: "Serverless function bundle is over Vercel's 50MB limit. Move heavy deps behind dynamic imports or split the function"
+  - match: "ENOENT"
+    hint: "Build is reading a file that exists locally but isn't tracked or isn't in the build output. Check .vercelignore and the includeFiles config"
+  - match: "Build exceeded maximum duration"
+    hint: "Build is over the 45-minute hard limit. Profile with `vercel build --debug` locally and look for hanging post-build scripts"
+  - match: "Environment Variable .* references Secret .* which does not exist"
+    hint: "Vercel project is missing a secret referenced in vercel.json or env config — add it via the dashboard before retrying"
+---
+
+# Vercel Deployment Runbook
+
+Vercel publishes commit check runs against the GitHub SHA on every deploy, separately for Preview and Production. The preferred polling path is GitHub Checks. The CLI fields (`cli_status_command`, `log_fetch_command`) are kept as a fallback for projects that disable the GitHub integration or run direct CLI deploys.
+
+**Multi-context note**: Vercel typically publishes more than one check run per commit (Preview + Production). `/verify-deployment` waits for **all** matching contexts to resolve and fails if any of them fails.
+
+## Manual troubleshooting
+
+When `/verify-deployment` exhausts its 3 fix iterations and escalates, walk this list:
+
+1. **Environment variables** — Vercel scopes env vars to Development / Preview / Production. A var that exists in Preview but not Production will pass preview builds and fail prod. Check the dashboard → Settings → Environment Variables.
+2. **Build output directory** — `vercel.json` `outputDirectory` mismatch causes the build to succeed but produce nothing to deploy. Default is `.next` for Next.js, `dist` for most others.
+3. **Node version drift** — Vercel uses the version pinned in `engines.node` (package.json) or the project's framework default. Local Node version mismatch is a frequent cause of "works locally, fails on Vercel".
+4. **Edge runtime constraints** — Functions declared with `export const runtime = 'edge'` can't use Node-only APIs (`fs`, `path`, native modules). The error message often points at the importing file but the actual culprit is a transitive dep.
+5. **ISR / caching** — A successful build can still produce a broken site if ISR is misconfigured. Check the deployment's Functions tab for revalidation errors.
+6. **Monorepo root directory** — In a monorepo, Vercel needs the `Root Directory` setting in the project config. Wrong root → "Cannot find package.json" with no other useful info.
+
+## Required setup on the project
+
+For `auth_check_command` to pass locally, the developer running `/verify-deployment` needs:
+
+- A logged-in Vercel CLI session (`vercel login` once), **or**
+- `VERCEL_TOKEN` exported in the shell environment
+
+For the GitHub Checks path to work, the Vercel → GitHub integration must be enabled on the repo (Vercel dashboard → Project Settings → Git).
+
+## Dashboard URL
+
+The `dashboard_url_template` interpolates `{project_id}` from the `Project ID` column of `CLAUDE.md` § Deployment Targets. For Vercel, `{project_id}` should be `<team-or-username>/<project-name>` (e.g. `acme/marketing-site`) so the resulting URL points at the project page.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -61,6 +61,30 @@ if git rev-parse --is-inside-work-tree &>/dev/null; then
   echo "🌿  GIT  branch: $BRANCH | uncommitted changes: $UNCOMMITTED"
 fi
 
+# ── Deployment Signal Nudge ──────────────────────────────────────────────────
+# If CLAUDE.md lacks a "## Deployment Targets" section AND any known deployment
+# signal file exists at the project root, print a one-line nudge. Non-blocking.
+# Suppressed by creating .claude/deploy-nudge-dismissed.
+if [ ! -f ".claude/deploy-nudge-dismissed" ] && [ -f "CLAUDE.md" ]; then
+  # Match ONLY a literal "## Deployment Targets" heading line — not headings with
+  # extra text like "## Deployment Targets — Schema Reference (Inactive Example)".
+  # This lets the template repo document the schema without activating verification.
+  if ! grep -qE '^## Deployment Targets[[:space:]]*$' CLAUDE.md 2>/dev/null; then
+    DEPLOY_SIGNAL=""
+    for signal in railway.json railway.toml .railway vercel.json .vercel .vercelignore netlify.toml fly.toml render.yaml; do
+      if [ -e "$signal" ]; then
+        DEPLOY_SIGNAL="$signal"
+        break
+      fi
+    done
+    if [ -n "$DEPLOY_SIGNAL" ]; then
+      echo ""
+      echo "⚠  Deploy signals detected ($DEPLOY_SIGNAL) but no Deployment Targets in CLAUDE.md."
+      echo "   Run /setup-deployment to enable automatic build verification."
+    fi
+  fi
+fi
+
 # ── Available Skills ────────────────────────────────────────────────────────
 echo ""
 echo "SKILLS AVAILABLE"

--- a/.claude/skills/setup-deployment/SKILL.md
+++ b/.claude/skills/setup-deployment/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: setup-deployment
+description: One-time interactive bootstrap for deployment verification. Scans the project for deployment signal files, asks the user to confirm detected services and project IDs, and writes the routing table into CLAUDE.md.
+disable-model-invocation: false
+---
+
+# /setup-deployment — Deployment Verification Bootstrap
+
+Configure `/verify-deployment` for this project. Scans the project for deployment signal files, confirms detected services with the user, prompts for the per-service routing details, and writes the `## Deployment Targets` section into `CLAUDE.md`.
+
+This skill is idempotent. Re-running it offers to update existing routing rather than duplicating it.
+
+---
+
+## Step 1 — Discover available adapters
+
+Read every runbook in `.claude/deployments/*.md` (excluding `README.md`). For each, parse the YAML frontmatter and extract:
+
+- `name`
+- `display_name`
+- `detect_files`
+
+Build an in-memory map: `{ name → { display_name, detect_files, runbook_path } }`.
+
+**If `.claude/deployments/` is missing or empty:**
+
+```
+No deployment runbooks found in .claude/deployments/.
+This template ships with starter runbooks for Railway and Vercel. If you ran
+/sync recently, those should be present. Otherwise, see .claude/deployments/README.md
+for how to author a new runbook.
+```
+
+Exit. Nothing to set up.
+
+---
+
+## Step 2 — Scan the project for deployment signals
+
+For each adapter from Step 1, check whether **any** of its `detect_files` exists at the project root. Any match counts as "service detected".
+
+Build a list of `detected_services` — adapters whose detection succeeded.
+
+**If `detected_services` is empty:**
+
+Ask the user:
+
+```
+No deployment signal files detected at the project root.
+Available adapters: <comma-separated display_names>
+
+Do you want to manually configure a service anyway? (y/n)
+```
+
+- **No** → exit 0 with `No deployment services configured. Run /setup-deployment again after adding a deployment config file (railway.json, vercel.json, etc.) to enable.`
+- **Yes** → present the full adapter list and let the user pick which to configure manually. Skip Step 3's auto-detect summary and go straight to Step 4 with the user's manual selection.
+
+**If `detected_services` is non-empty**, present the summary:
+
+```
+Detected deployment services:
+
+  ✓ <display_name 1> (matched: <detect_file>)
+  ✓ <display_name 2> (matched: <detect_file>)
+
+Configure verification for these services? (y/n/edit)
+```
+
+- **y** → proceed to Step 3 with the auto-detected list
+- **n** → exit 0 (no changes)
+- **edit** → let the user toggle individual services in/out before proceeding
+
+---
+
+## Step 3 — Per-service interview
+
+For each confirmed service, ask:
+
+```
+<display_name>:
+  Triggers on branch [default: main]:
+  Project ID (used for dashboard links):
+```
+
+- **Triggers on branch** — the branch name whose pushes should trigger this service's build. Default `main`. Accept globs (e.g. `preview/*`) for projects with preview environments.
+- **Project ID** — free-form identifier the runbook will interpolate into its `dashboard_url_template`. Tell the user the format expected by the runbook (read the runbook's "Dashboard URL" body section if present).
+
+Store the responses as `{ service_name → { branch, project_id } }`.
+
+---
+
+## Step 4 — Check existing CLAUDE.md state
+
+Read `CLAUDE.md`. Look for an existing `## Deployment Targets` section.
+
+| Existing state | Action |
+|---|---|
+| Section absent | Append a new section at the end of CLAUDE.md (after the last existing section) |
+| Section present, no overlapping services | Add the new rows to the existing table; preserve existing rows |
+| Section present, same service appears | Ask: `<service> is already configured for branch <X>. Replace with the new branch <Y>? (y/n)` — replace on yes, skip on no |
+
+**Format of the inserted section:**
+
+```markdown
+## Deployment Targets
+
+> Populated by `/setup-deployment`. Read by `/verify-deployment`.
+> Delete this section to disable deployment verification for this project.
+
+| Service       | Runbook                          | Triggers on branch | Project ID    |
+|---------------|----------------------------------|--------------------|---------------|
+| <display_1>   | .claude/deployments/<name_1>.md  | <branch_1>         | <project_1>   |
+| <display_2>   | .claude/deployments/<name_2>.md  | <branch_2>         | <project_2>   |
+
+**Config:**
+- Max fix iterations: 3
+- Build timeout: 15m
+- Preferred status source: github-checks
+```
+
+The Config block defaults are inserted as-is on a fresh setup. If the section already had a Config block, preserve the user's existing values rather than overwriting.
+
+---
+
+## Step 5 — Verify runbook files are in place
+
+For each confirmed service, verify `.claude/deployments/<name>.md` exists. It should — we read it in Step 1 — but check anyway in case the directory was modified between steps.
+
+If any runbook is missing, abort with:
+
+```
+Runbook missing: .claude/deployments/<name>.md
+This shouldn't happen after Step 1 succeeded. Run /sync to re-pull template files.
+```
+
+---
+
+## Step 6 — Update `.gitignore`
+
+Read `.gitignore` (create it if missing). Ensure these entries exist:
+
+```
+tasks/deploy-state.json
+tasks/deploy-logs-*.log
+```
+
+Add any missing entries with a comment header:
+
+```
+# Deployment verification state — per-session, not committed
+tasks/deploy-state.json
+tasks/deploy-logs-*.log
+```
+
+If both entries are already present (verbatim or via a broader pattern like `tasks/*.json`), make no changes.
+
+---
+
+## Step 7 — Final report
+
+Output:
+
+```
+Deployment verification configured.
+
+Targets:
+  ✓ <display_1> on branch <branch_1>
+  ✓ <display_2> on branch <branch_2>
+
+Next steps:
+  1. Verify your auth is set up: <auth_check_command from each runbook>
+  2. Push a commit to a configured branch
+  3. Run /verify-deployment (or /wrap-up-session, which calls it automatically)
+
+To disable: delete the "## Deployment Targets" section from CLAUDE.md.
+To suppress the session-start nudge without enabling: touch .claude/deploy-nudge-dismissed
+```
+
+---
+
+## Edge Cases
+
+- **No `CLAUDE.md` at the project root** — abort with: `CLAUDE.md not found at the project root. /setup-deployment requires CLAUDE.md to write the routing table into.`
+- **Multiple detect_files match for the same service** — that's fine, just pick the first matching file for the summary line. The service is still listed once.
+- **User runs setup with services already configured** — Step 4's merge logic handles this without duplication. The interview in Step 3 only re-asks for services the user explicitly confirms in Step 2.
+- **Two different runbooks declare overlapping `detect_files`** (e.g. both list `Dockerfile`) — list both as detected and let the user toggle in the `edit` flow. Don't auto-pick.
+- **Project root is not a git repo** — proceed anyway. `/verify-deployment` will fail at its own pre-flight, but `/setup-deployment` is just writing config.
+- **Runbook frontmatter is malformed** at Step 1 — skip that runbook with a warning, continue with the rest. Don't crash.
+
+---
+
+## Invariants
+
+1. **Idempotent** — running setup twice with the same answers produces the same `CLAUDE.md` state, not duplicate rows.
+2. **Non-destructive** — never overwrites a user's existing Config block values; never removes existing rows for services the user didn't re-confirm.
+3. **No hardcoded service list** — discovery is purely from `.claude/deployments/*.md`. Adding a new runbook there makes it immediately available to setup.
+4. **Writes are confined to** `CLAUDE.md` and `.gitignore`. No other files are modified.

--- a/.claude/skills/verify-deployment/SKILL.md
+++ b/.claude/skills/verify-deployment/SKILL.md
@@ -1,0 +1,297 @@
+---
+name: verify-deployment
+description: Wait for post-push deployment builds to resolve, fetch logs on failure, and loop a code-debugger fix cycle up to 3 iterations before escalating. Service-agnostic — driven by runbook files in .claude/deployments/.
+disable-model-invocation: false
+---
+
+# /verify-deployment — Post-Push Deployment Verification
+
+Wait for the deployment service(s) configured in `CLAUDE.md` § Deployment Targets to finish building the current commit. On failure, fetch logs, delegate the fix to `code-debugger`, push the fix as a new commit, and loop. Maximum 3 fix iterations per service before escalation.
+
+This skill is **service-agnostic by construction**. No specific deployment service is named anywhere in this file. All service-specific behavior comes from runbook files in `.claude/deployments/<service>.md`. Adding a new service is a drop-in change to that directory.
+
+---
+
+## Pre-Flight
+
+### 1. Reject uncommitted changes
+
+Run `git status --porcelain`. If any output:
+
+```
+STOP — Uncommitted changes present.
+/verify-deployment requires a clean working tree because it pushes new commits
+during fix iterations. Commit or stash your changes and re-run.
+```
+
+Exit. Do not proceed.
+
+### 2. Locate the routing table
+
+Read `CLAUDE.md`. Look for a section header line that matches **exactly** `^## Deployment Targets[[:space:]]*$` — the heading must be `## Deployment Targets` with no trailing text. Headings like `## Deployment Targets — Schema Reference (Inactive Example)` are intentionally not matched, so the template repo can document the schema without activating verification.
+
+**If the section is missing:**
+
+- For each runbook in `.claude/deployments/*.md` (excluding `README.md`), parse its frontmatter and read `detect_files`
+- Check the project root for any matching signal file
+- **If any signal matches**: print
+  ```
+  Deploy signals detected (<file>). Run /setup-deployment to enable automatic build verification.
+  ```
+  Exit 0 — nothing to verify.
+- **If no signals match**: exit 0 silently. The project does not use a recognized deployment service.
+
+**If the section exists:** parse the table. Each row has columns `Service | Runbook | Triggers on branch | Project ID`. Also parse the optional config block below the table for `Max fix iterations`, `Build timeout`, `Preferred status source`.
+
+### 3. Resolve git context
+
+Run:
+
+- `git rev-parse HEAD` → current commit SHA
+- `git rev-parse --abbrev-ref HEAD` → current branch
+- `git remote get-url origin` → confirm a remote exists (else escalate: "No remote configured — cannot poll for deployment")
+
+### 4. Filter applicable targets
+
+Keep only target rows whose `Triggers on branch` matches the current branch. Branch matching is **exact** unless the target row uses a glob (e.g. `preview/*`); if a glob is present, match the current branch against it.
+
+**If the filtered set is empty:**
+
+```
+No deployment targets trigger on branch <current-branch>. Skipping verification.
+```
+
+Exit 0.
+
+---
+
+## Per-Target Verification
+
+For each applicable target, in the order they appear in the table:
+
+### Step A — Load and validate the runbook
+
+Read the runbook file referenced by the `Runbook` column. Parse the YAML frontmatter. Validate against the contract documented in `.claude/deployments/README.md`:
+
+- Required (always): `name`, `display_name`, `detect_files`, `status_source`, `auth_check_command`, `dashboard_url_template`, `default_timeout_minutes`
+- If `status_source: github-checks` → `check_contexts` is required
+- If `status_source: cli` → `cli_status_command` is required
+- `name` must match the filename stem
+- `common_failure_patterns` entries (if present) must each have both `match` and `hint`
+
+**If validation fails:** report the specific error and skip this target. Do not crash. Continue with the next target.
+
+```
+<display_name>: malformed runbook — <specific reason>. Skipping this target.
+```
+
+### Step B — Auth check (fail fast)
+
+Run the runbook's `auth_check_command`. If it exits non-zero:
+
+```
+<display_name>: auth check failed.
+Run `<auth_check_command>` manually and resolve credentials before retrying.
+This does NOT count as a fix iteration.
+```
+
+Mark this target as `AUTH_FAILED` and move to the next target.
+
+### Step C — Poll for build status
+
+Initialize:
+
+- `started_at` = now
+- `iteration` = current value from `tasks/deploy-state.json` for this `{commit_sha, service}` key, or `0`
+- `timeout` = CLAUDE.md config `Build timeout` if set, else runbook `default_timeout_minutes`
+- `max_iterations` = CLAUDE.md config `Max fix iterations` if set, else `3`
+
+Persist `{ service, iteration, last_sha, started_at }` to `tasks/deploy-state.json` so a session resume can pick up where polling left off.
+
+**Polling loop** (until terminal status or timeout):
+
+- **github-checks path**: call `mcp__github__get_commit` with the current commit SHA. Filter the returned check runs by name against the runbook's `check_contexts` list. **All matching contexts must resolve to success** — some services publish more than one check run per commit (e.g. separate Preview and Production contexts), and a single failure on any context fails the target.
+  - States: `queued`, `in_progress`, `pending` → keep waiting
+  - State `completed` with conclusion `success` → that context is done
+  - State `completed` with conclusion `failure` / `cancelled` / `timed_out` → record the failing context, abort polling, jump to Step D
+- **cli path**: run the runbook's `cli_status_command`. Parse the JSON output for a `state` or `status` field. Map values:
+  - `pending` / `building` / `queued` → keep waiting
+  - `success` / `ready` / `live` → done
+  - `failed` / `error` / `cancelled` → jump to Step D
+
+**Poll intervals**: 15 seconds for the first 2 minutes, then 30 seconds. Cap total wait at `timeout` minutes.
+
+**Transient errors** (network failure, GitHub API 5xx, runbook command exit 124) are retried at the polling layer with exponential backoff (5s → 10s → 20s, then back to normal interval). They do **not** consume a fix iteration.
+
+**Terminal states:**
+
+| Status | Action |
+|---|---|
+| All contexts SUCCESS | Record `<display_name>: SUCCESS (iteration N+1 attempts)`. Move to next target. |
+| Any FAILURE | Jump to Step D (fix-loop) |
+| CANCELLED | Ask user: `<display_name>: build was cancelled — retry deployment? (y/n)`. If yes, restart Step C. If no, mark `CANCELLED`, move to next target. |
+| TIMEOUT (no resolution within window) | Mark `TIMEOUT`, write the dashboard URL (interpolate `dashboard_url_template` with the project_id from the table row), move to next target. |
+
+### Step D — Fix loop
+
+Pre-condition: `iteration < max_iterations`. If `iteration >= max_iterations`, jump to Step E (escalation) immediately without spending another attempt.
+
+#### D.1 — Fetch logs
+
+Determine the source:
+
+- **github-checks** with `log_fetch_command` set: prefer the runbook's `log_fetch_command`, interpolating `{deployment_id}` from the failing check run's `external_id` or `details_url`
+- **github-checks** without `log_fetch_command`: fetch the check run's `details_url` (the build's web page) — this is best-effort; many services don't expose plain-text logs at that URL
+- **cli**: run `log_fetch_command` with `{deployment_id}` from the prior status response
+
+Truncate logs to the last 500 lines if larger to fit the debugger's context window. Keep the original full log saved at `tasks/deploy-logs-<service>-<sha>.log` (gitignored via the same pattern as `deploy-state.json`).
+
+#### D.2 — Match failure patterns
+
+Scan the fetched logs for each `match` substring in the runbook's `common_failure_patterns`. Collect all matching `hint` strings. These are pre-curated debugging shortcuts — they go into the debugger's context.
+
+#### D.3 — Delegate to `code-debugger` agent
+
+Invoke the `code-debugger` agent with `model: "sonnet"`. The prompt must include:
+
+- The failing service's `display_name`
+- The (truncated) build logs
+- The matched hints from D.2
+- The runbook's body content (the human-readable troubleshooting section after the frontmatter)
+- The current commit SHA
+- The output of `git diff origin/main...HEAD` (changes since the base branch)
+- A clear instruction: "Diagnose the root cause and apply a fix. Run the local test suite to confirm the fix doesn't regress anything. Do NOT commit — the calling skill will create the commit. Report what you changed and why."
+
+**If the code-debugger reports it cannot find a fix** (no diff produced, or explicit "I don't know"): treat that as a failed iteration. Increment the counter. Log the reason. Continue to D.4 anyway — the escalation path will catch it after 3 attempts.
+
+#### D.4 — Commit the fix as a NEW commit
+
+Never amend. Each iteration must produce a distinct SHA so the deployment service has something new to build.
+
+Stage the files the debugger touched:
+
+```
+git add <files-the-debugger-modified>
+git commit -m "fix(deploy): <one-line summary from debugger> [deploy-retry N/3]"
+```
+
+Where `N` is the new iteration number (1-indexed in the message).
+
+#### D.5 — Push
+
+```
+git push origin <current-branch>
+```
+
+Apply the same push failure handling as `/wrap-up-session` Step 7:
+
+| Failure | Action |
+|---|---|
+| Network error | Retry up to 4 times with backoff 2s → 4s → 8s → 16s |
+| Non-fast-forward | `git pull --rebase`, resolve any conflicts, re-run, push again |
+| Permission denied | Escalate to user — do not retry |
+| Branch protection | Escalate to user — do not retry |
+
+#### D.6 — Increment and loop
+
+- `iteration` += 1
+- Update `tasks/deploy-state.json` with the new SHA from step D.4 and the incremented counter
+- Restart Step C with the new SHA
+
+### Step E — Escalation after max iterations
+
+When `iteration >= max_iterations` and the latest build still failed, write `tasks/deploy-report.md` with:
+
+```markdown
+# Deployment Failure Report
+
+**Service**: <display_name>
+**Branch**: <branch>
+**Final commit**: <sha>
+**Dashboard**: <dashboard_url with {project_id} interpolated>
+**Attempts**: <N> (max reached)
+
+## Iteration history
+
+| # | Commit | Result | Debugger summary |
+|---|--------|--------|------------------|
+| 1 | <sha-1> | failure | <one-line> |
+| 2 | <sha-2> | failure | <one-line> |
+| 3 | <sha-3> | failure | <one-line> |
+
+## Final logs (last 500 lines)
+
+```
+<paste>
+```
+
+## Matched failure hints
+
+- <hint 1>
+- <hint 2>
+
+## Suggested manual remediation
+
+The fix loop exhausted itself, which usually means the failure is not fixable in code:
+
+1. Check environment variables in the service dashboard
+2. Check for quota / billing / rate-limit issues
+3. Check that any required secrets are configured
+4. Review the runbook's "Manual troubleshooting" section
+5. Consider whether the build command, framework version, or runtime needs changing in the service's settings (not in code)
+```
+
+Mark this target as `FAILED_MAX_ITERATIONS` and move to the next target.
+
+---
+
+## Reporting
+
+After all targets have a terminal state, output a per-target summary table:
+
+```
+Deployment Verification Results:
+| Service           | Status                  | Attempts | Notes |
+|-------------------|-------------------------|----------|-------|
+| <display_name 1>  | SUCCESS                 | 1        | —     |
+| <display_name 2>  | FAILED_MAX_ITERATIONS   | 3        | See tasks/deploy-report.md |
+```
+
+**Overall outcome** is the worst case across all targets:
+
+| Per-target states present | Overall outcome | Caller action |
+|---|---|---|
+| All SUCCESS | `ALL_GREEN` | Caller proceeds |
+| Any AUTH_FAILED | `AUTH_FAILED` | Caller STOPs (credentials must be fixed) |
+| Any TIMEOUT | `TIMEOUT` | Caller STOPs and asks user |
+| Any CANCELLED (after user said no) | `CANCELLED` | Caller STOPs |
+| Any FAILED_MAX_ITERATIONS | `FAILED_MAX_ITERATIONS` | Caller STOPs (deploy-report.md exists) |
+| All targets skipped (branch mismatch / missing section) | `SKIPPED` | Caller proceeds |
+
+Clean up `tasks/deploy-state.json` only on `ALL_GREEN` or `SKIPPED` — leaving it in place after a failure lets a re-run pick up at the right iteration count.
+
+---
+
+## Edge Cases
+
+- **Commit SHA changes mid-loop** (user pushed a new commit manually, force-pushed, or amended): on the next poll cycle, `git rev-parse HEAD` differs from `last_sha` in the state file. Abort the loop, warn the user: `Commit SHA changed during deployment verification — aborting loop. Re-run /verify-deployment to start over.`
+- **Multiple check runs per service**: handled by checking that **all** contexts in `check_contexts` resolve to success. If 2 of 3 succeed and 1 fails, the target is FAILED.
+- **No check runs returned within the first 30 seconds** (the service hasn't picked up the push yet): keep polling at the normal cadence. Don't escalate this as a failure — the service may be slow to register.
+- **Runbook references a CLI that isn't installed**: `auth_check_command` exits non-zero (command not found = exit 127), which triggers the AUTH_FAILED path. Report includes "command not found — install the CLI or switch to github-checks".
+- **`.claude/deployments/` directory missing entirely**: there are no runbooks to validate against. Skip verification with: `No runbooks found in .claude/deployments/. Run /setup-deployment to populate.`
+- **CLAUDE.md `Deployment Targets` section references a runbook file that doesn't exist**: skip that target with `<service>: runbook file not found at <path>`. Continue with other targets.
+- **Code-debugger applies a fix that breaks local tests**: per the debugger's own protocol, it should report failure rather than commit. If a diff exists but tests fail, do NOT commit — skip directly to D.6 (count as failed iteration).
+
+---
+
+## Invariants
+
+These properties of this skill are load-bearing:
+
+1. **No hardcoded service names.** Every behavior that varies between deployment services flows from runbook frontmatter. Adding a new service is a drop-in `.claude/deployments/<service>.md` file with zero edits to this skill.
+2. **Auth failure does not consume a fix-iteration slot.** AUTH_FAILED is a separate terminal state, reached before any iteration counter increments.
+3. **Each fix iteration produces a NEW commit.** Never amend. Each retry needs a distinct SHA for the deployment service to rebuild.
+4. **Maximum 3 fix iterations.** After the third failed build, write the report and stop. The user must intervene.
+5. **Transient API errors retry at the polling layer**, not at the fix-loop layer. A flaky GitHub Checks call should not consume a fix attempt.
+6. **State persists across re-runs** via `tasks/deploy-state.json`, scoped by `{commit_sha, service}` so resuming is possible. Cleared only on `ALL_GREEN` or `SKIPPED`.
+7. **Pre-flight rejects uncommitted changes** so the fix loop never accidentally commits unrelated work.

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -374,6 +374,48 @@ If `git push` fails:
 
 ---
 
+## Step 8 — Deployment Verification
+
+After a successful push, verify that any deployment service watching this branch actually builds the new commit. The session is not "wrapped up" if production is broken.
+
+This step is **conditional** — it only runs when the project has opted in by adding a `## Deployment Targets` section to `CLAUDE.md`. For projects that don't deploy via PaaS, this step is a silent no-op.
+
+### Opt-out
+
+If `/wrap-up-session` was invoked with `--skip-deploy` (for WIP pushes that aren't expected to build cleanly), skip this step entirely and proceed to Done. Note in the Done banner: `Deployments: [SKIPPED — --skip-deploy flag]`.
+
+### Conditional dispatch
+
+1. Read `CLAUDE.md` and check for a section header line matching **exactly** the regex `^## Deployment Targets[[:space:]]*$`. Headings like `## Deployment Verification — Schema Reference (Inactive Example)` are intentionally not matched, so the template repo can document the schema without activating verification.
+
+2. **If the strict-match section exists**: invoke the `/verify-deployment` skill. That skill handles all polling, log fetching, fix iteration, and escalation per its own contract (`.claude/skills/verify-deployment/SKILL.md`). Wait for it to return a per-target outcome.
+
+3. **If the section is missing**: read every runbook in `.claude/deployments/*.md`, collect every entry from each runbook's `detect_files` field, then scan the project root for any matching file or directory. (No service names are hardcoded here — the list of signals is whatever the shipped runbooks declare.)
+   - **If a signal file is found**: print a one-line nudge and proceed to Done (do not block):
+     ```
+     Deploy signals detected (<file>). Run /setup-deployment to enable automatic build verification.
+     ```
+   - **If no signal file is found**: skip silently and proceed to Done. The project does not deploy via a recognized service.
+
+### Outcome handling
+
+The `/verify-deployment` skill returns one of these overall outcomes. Map each to a Done/STOP action:
+
+| `/verify-deployment` outcome | Action |
+|---|---|
+| `ALL_GREEN` | Proceed to Done. Record per-target attempt counts in the Done banner. |
+| `SKIPPED` (no targets matched current branch, or no `Deployment Targets` section) | Proceed to Done. Banner shows `Deployments: [SKIPPED — reason]`. |
+| `AUTH_FAILED` | **STOP** — credentials are missing for one or more targets. Report which `auth_check_command` failed and ask: _"Resolve credentials and re-run /verify-deployment manually, or proceed without verification? (retry/proceed)"_. Do not claim session success on `proceed` without explicit user override. |
+| `TIMEOUT` | **STOP** — one or more builds did not resolve within the configured timeout. Report the dashboard URL(s) and ask: _"Check the deployment dashboard manually. Mark as wrapped up anyway? (y/n)"_. Do not claim success on `n`. |
+| `CANCELLED` | **STOP** — a build was cancelled (after the user already declined to retry inside `/verify-deployment`). Report and ask: _"A deployment was cancelled. Proceed with wrap-up anyway? (y/n)"_. |
+| `FAILED_MAX_ITERATIONS` | **STOP** — `/verify-deployment` exhausted its 3-iteration fix loop. Point the user to `tasks/deploy-report.md` and DO NOT claim session success. The session is not wrapped up while production is failing. |
+
+### Why this lives in wrap-up-session
+
+`/build` does not push, so the deployment service never sees its commits. Verification is strictly a wrap-up concern — the only place in the workflow where code reaches the remote and triggers a real build.
+
+---
+
 ## Done
 
 Reply:
@@ -388,4 +430,5 @@ Session wrapped up.
   - NITPICK: [N found, skipped]
 - Tests: [PASS — suite name] or [FAIL — see above] or [SKIPPED — no test suite]
 - Pushed: [yes / no — reason] [user-approved if review gate was overridden]
+- Deployments: [<service> ✓ (N attempts), <service> ✓ (N attempts)] or [<service> ✗ FAILED after 3 attempts — see tasks/deploy-report.md, <service> ✓] or [SKIPPED — reason] or [NONE — no Deployment Targets configured]
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Deployment verification state — per-session, not committed
+tasks/deploy-state.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Run `/build` to execute the plan autonomously:
 
 ### 4. Wrap Up
 After any user correction: note the root cause in `tasks/lessons.md`.
-At session end: run `/wrap-up-session` to sync learnings, tests, and push.
+At session end: run `/wrap-up-session` to sync learnings, tests, push, and **verify the deployment build** (Step 8). If the project has a `## Deployment Targets` section in this file, wrap-up will not claim success until the post-push build resolves green — looping a `code-debugger` fix cycle up to 3 times before escalating.
 
 ---
 
@@ -113,7 +113,9 @@ Invoke with `/skill-name` in the chat. Each skill is a directory under `.claude/
 | `/checkpoint` | Snapshot progress to `tasks/checkpoint.md` for handoff or pause |
 | `/security-scan` | OWASP-focused audit on recently changed files |
 | `/start-qa` | Restart app, health check, launch browser with log monitoring for manual QA |
-| `/wrap-up-session` | Sync learnings, update task/bug registers, run tests, verify, merge worktree, push |
+| `/setup-deployment` | One-time interactive bootstrap: scan for deploy signals, write `## Deployment Targets` routing into this file |
+| `/verify-deployment` | Wait for post-push deployment build, fetch logs on failure, loop a `code-debugger` fix cycle up to 3 iterations before escalating |
+| `/wrap-up-session` | Sync learnings, update task/bug registers, run tests, verify, merge worktree, push, **then verify deployment build (Step 8)** |
 | `/writing-skills` | Author new skills with proper structure, iron laws, and reference docs |
 | `/sync` | Pull latest skills, hooks, agents from the template repo into the current project |
 | `/folder-context-optimization` | Sweep a folder for legacy/unused files, propose archival |
@@ -169,6 +171,7 @@ Before marking any task complete, confirm:
 .claude/agents/            → Specialized subagents (invoked via Agent tool)
 .claude/skills/            → Skills invokable with /skill-name
 .claude/hooks/             → Lifecycle automation scripts
+.claude/deployments/       → Per-service deployment runbooks (adapter pattern for /verify-deployment)
 specs/                     → Feature specifications
 specs/prd-<name>.md        → Product Requirements Document (from /prd)
 tasks/backlog.md           → Ordered work items by phase (from /prd)
@@ -177,4 +180,47 @@ tasks/todo.md              → Active task plan for current feature (from /plan)
 tasks/bugs.md              → Bug register (opened/fixed per session)
 tasks/lessons.md           → Self-improvement patterns
 tasks/checkpoint.md        → Session snapshots
+tasks/deploy-state.json    → Per-session deployment iteration state (gitignored)
+tasks/deploy-report.md     → Deployment failure report (written by /verify-deployment after max iterations)
 ```
+
+---
+
+## Deployment Verification — Schema Reference (Inactive Example)
+
+> ⚠ **THIS REPO HAS NO ACTIVE DEPLOYMENT TARGETS.** This is the template repo and it doesn't deploy anywhere. The block below documents the schema that downstream projects will populate via `/setup-deployment`. The section header is intentionally **not** the literal `## Deployment Targets` so that `/verify-deployment` and `session-start.sh` treat this repo as having no Deployment Targets and skip silently.
+
+**Downstream projects** that want to enable deployment verification should run `/setup-deployment`, which writes a real `## Deployment Targets` section near the bottom of this file (matched by the exact-match regex `^## Deployment Targets[[:space:]]*$`).
+
+The schema below uses indented code blocks (not fenced) so no `## Deployment Targets` line appears at column 0 in this template repo. A real configured project would look like this:
+
+        ## Deployment Targets
+
+        > Populated by /setup-deployment. Read by /verify-deployment.
+        > Delete this section to disable deployment verification for this project.
+
+        | Service | Runbook                          | Triggers on branch | Project ID    |
+        |---------|----------------------------------|--------------------|---------------|
+        | Railway | .claude/deployments/railway.md   | main               | my-api-prod   |
+        | Vercel  | .claude/deployments/vercel.md    | main               | acme/marketing |
+
+        **Config:**
+        - Max fix iterations: 3
+        - Build timeout: 15m
+        - Preferred status source: github-checks
+
+**Schema rules:**
+
+- The section heading must be **exactly** `## Deployment Targets` (no trailing text). `/verify-deployment` and the session-start hook both match this header with the regex `^## Deployment Targets[[:space:]]*$` so any extra text disables verification.
+- `Service` — display name (free-form, used in reports)
+- `Runbook` — relative path to a runbook file in `.claude/deployments/` whose frontmatter declares the service-specific contract
+- `Triggers on branch` — exact branch name or glob (e.g. `preview/*`); only targets matching the current branch are verified on a given push
+- `Project ID` — free-form string interpolated into the runbook's `dashboard_url_template`; consult each runbook for the expected format
+
+**Config block** (optional, overrides runbook defaults):
+
+- `Max fix iterations` — how many times `/verify-deployment` will loop the `code-debugger` fix cycle before escalating
+- `Build timeout` — max wait per build attempt before declaring `TIMEOUT`
+- `Preferred status source` — `github-checks` (default) or `cli`
+
+To add a new deployment service, drop a runbook file into `.claude/deployments/<service>.md` following the contract in `.claude/deployments/README.md`, then re-run `/setup-deployment`.

--- a/specs/deployment-verification.md
+++ b/specs/deployment-verification.md
@@ -1,0 +1,277 @@
+# Spec: Deployment Verification
+
+## Problem
+
+`/wrap-up-session` declares "session wrapped up" after `git push`, but the work isn't actually done — Railway, Vercel, and similar PaaS providers then run their own builds in the cloud. If that build fails, the user discovers it later, out-of-band, with no loop back into the coding workflow. There is no mechanism in the current template to:
+
+1. Know which deployment services a project uses
+2. Wait for the post-push build
+3. Fetch build logs on failure
+4. Iterate a fix loop until the build succeeds
+
+The routing must not hardcode service names — adding Fly.io, Render, or Netlify later should be a drop-in change, not a rewrite.
+
+## Behavior
+
+Introduce a **Deployment Verification** layer with four mechanisms:
+
+1. **Declarative routing in `CLAUDE.md`** — a `## Deployment Targets` section lists which services this project uses, which branches trigger each, and points to per-service runbook files. This is the project-level source of truth.
+2. **Adapter runbooks in `.claude/deployments/<service>.md`** — each deployment service is a self-contained markdown file with YAML frontmatter declaring detection files, status source, auth check, log fetch, and common failure hints. Adding a new service = drop in a new file.
+3. **New skill `/verify-deployment`** — reads the CLAUDE.md routing table, filters by current branch, waits for each applicable service's build to resolve (primary source: GitHub Checks API via GitHub MCP; fallback: per-service CLI when the runbook declares it), fetches logs on failure, delegates fixes to the `code-debugger` agent, commits each fix as a new commit, and loops up to 3 iterations before escalating.
+4. **New skill `/setup-deployment`** — one-time interactive bootstrap that scans the project for deployment signal files, asks the user to confirm detected services and project IDs, writes the `## Deployment Targets` section into `CLAUDE.md`, and copies starter runbook files from the template.
+
+`/wrap-up-session` grows a new **Step 8: Deployment Verification** that invokes `/verify-deployment` after the push succeeds. `/build` is unchanged — it does not push, so deployment is strictly a wrap-up concern.
+
+## Design
+
+### 1. `CLAUDE.md` — `## Deployment Targets` section
+
+Added as an optional section near the end of `CLAUDE.md`. When absent, `/verify-deployment` is a no-op (with a nudge if signal files exist). When present:
+
+```markdown
+## Deployment Targets
+
+> Populated by `/setup-deployment`. Read by `/verify-deployment`.
+> Delete this section to disable deployment verification for this project.
+
+| Service | Runbook                          | Triggers on branch | Project ID    |
+|---------|----------------------------------|--------------------|---------------|
+| Railway | .claude/deployments/railway.md   | main               | my-api-prod   |
+| Vercel  | .claude/deployments/vercel.md    | main               | my-frontend   |
+
+**Config:**
+- Max fix iterations: 3
+- Build timeout: 15m
+- Preferred status source: github-checks
+```
+
+Rules:
+- A target row whose `Triggers on branch` does not match the current branch is skipped silently.
+- `Project ID` is free-form — its only consumer is the runbook's `dashboard_url_template`.
+- Config values at the bottom override runbook defaults.
+
+### 2. Runbook schema — `.claude/deployments/<service>.md`
+
+Every runbook is a markdown file with YAML frontmatter. The frontmatter is the machine-readable contract; the body is human-readable troubleshooting notes.
+
+```yaml
+---
+name: railway                                    # lowercase identifier
+display_name: Railway                            # for reports
+detect_files:                                    # any match = this service is present
+  - railway.json
+  - railway.toml
+  - .railway/
+status_source: github-checks                     # or: cli
+check_contexts:                                  # GitHub check run names (status_source=github-checks)
+  - Railway
+  - railway/deployment
+auth_check_command: railway whoami               # must exit 0 before wait begins
+cli_status_command: railway status --json        # used only if status_source=cli
+log_fetch_command: railway logs --deployment {deployment_id}
+dashboard_url_template: https://railway.app/project/{project_id}
+default_timeout_minutes: 15
+common_failure_patterns:
+  - match: "npm ERR! peer dep"
+    hint: "Peer dependency mismatch — check package.json"
+  - match: "Nixpacks build failed"
+    hint: "Check buildCommand in railway.json"
+---
+
+# Railway Deployment Runbook
+
+## Manual troubleshooting
+...
+```
+
+**Contract rules** (enforced by `/verify-deployment` on read):
+- `name`, `detect_files`, `status_source`, `auth_check_command`, `dashboard_url_template` are required
+- If `status_source: github-checks` → `check_contexts` is required
+- If `status_source: cli` → `cli_status_command` is required
+- `common_failure_patterns` is optional; when present, matches add hints to the debugger's context
+
+### 3. `/verify-deployment` skill
+
+**Inputs**: current commit SHA (`git rev-parse HEAD`), current branch (`git rev-parse --abbrev-ref HEAD`), CLAUDE.md contents, `.claude/deployments/*.md` runbooks.
+
+**Flow**:
+
+```
+1. Read CLAUDE.md, locate "## Deployment Targets" section.
+   - If missing:
+       - Scan project root for any detect_files from runbooks in .claude/deployments/
+       - If signals found: print nudge "Deploy signals found (railway.json). Run /setup-deployment to enable."
+       - Exit 0 (nothing to verify).
+   - If present: parse the target table.
+
+2. Resolve current commit SHA and branch.
+
+3. Filter targets: keep rows where the current branch matches "Triggers on branch".
+   - Empty set: report "No deployment targets trigger on branch <X>". Exit 0.
+
+4. For each applicable target:
+   a. Load its runbook. Validate frontmatter against the contract.
+   b. Run auth_check_command. Non-zero exit:
+        → STOP this target, report "<service>: auth check failed — run <command> manually".
+        → Do not count as a fix iteration.
+   c. Poll for build status:
+        - github-checks path: call mcp__github__get_commit for the SHA, filter check runs by check_contexts names
+        - cli path: run cli_status_command, parse output per runbook
+        - Poll intervals: 15s for first 2min, then 30s. Cap at default_timeout_minutes (or CLAUDE.md config override).
+   d. Resolve status:
+        - pending / in_progress / queued → keep waiting
+        - success → record ✓ and move to next target
+        - failure → enter fix-loop (step e)
+        - cancelled → STOP this target, ask user "Build was cancelled — deploy intentionally? (y/n)"
+        - timeout (no resolution within window) → STOP this target, escalate with dashboard URL
+   e. Fix-loop (max 3 iterations; counter persisted in tasks/deploy-state.json per-service):
+        i.   Fetch logs:
+                - github-checks: extract the check run's details_url, fetch via webfetch or fallback to runbook's log_fetch_command if set
+                - cli: run log_fetch_command with deployment_id from the status response
+        ii.  Scan logs against runbook.common_failure_patterns — collect matching hints.
+        iii. Delegate to code-debugger agent (model: sonnet) with:
+                - Full logs (or tail if > 500 lines)
+                - Matched hints
+                - Runbook body (troubleshooting section)
+                - Current commit SHA
+                - git diff origin/main...HEAD for context
+        iv.  Code-debugger applies the fix and runs the local test suite (existing debug flow).
+        v.   Commit as a NEW commit (never amend): "fix(deploy): <one-line summary> [deploy-retry N/3]"
+        vi.  Push (reuses wrap-up-session's push failure handling: retry on network, pull --rebase on non-FF).
+        vii. Restart step c (wait for new SHA) with incremented iteration counter.
+   f. After 3 failed iterations: STOP this target.
+        - Write tasks/deploy-report.md with: iteration history, final logs, matched hints, dashboard URL, suggested manual remediation steps (env vars, quotas, infra).
+        - Flag the session as "deployment failed".
+
+5. Report per-target status and overall outcome.
+```
+
+**Output states** (per target): `SUCCESS`, `AUTH_FAILED`, `TIMEOUT`, `CANCELLED`, `FAILED_MAX_ITERATIONS`.
+
+**State file**: `tasks/deploy-state.json` — tracks `{ service, iteration, last_sha, started_at }` per active verification. Cleaned up on terminal state. Not committed (added to `.gitignore` via a note in setup-deployment).
+
+### 4. `/setup-deployment` skill
+
+**Flow**:
+
+```
+1. Scan project root for detect_files across all runbooks in .claude/deployments/
+   (e.g., vercel.json, railway.json, netlify.toml, fly.toml, render.yaml).
+2. Present detected services to user:
+     "I detected: Railway (railway.json), Vercel (vercel.json). Confirm? (y/n)"
+3. For each confirmed service:
+     - Ask: "Which branch triggers <service>? [default: main]"
+     - Ask: "Project ID for <service>? (used for dashboard links)"
+4. If CLAUDE.md has no "## Deployment Targets" section, append it.
+   If it has one, offer to replace or merge.
+5. For each confirmed service, ensure .claude/deployments/<service>.md exists.
+   If missing (new project using /sync), copy from template.
+6. Ensure tasks/deploy-state.json is in .gitignore.
+7. Report: "Deployment verification configured for: Railway, Vercel. Run /verify-deployment after a push to test."
+```
+
+### 5. `/wrap-up-session` — new Step 8
+
+Inserted between the current Step 7 (Commit & Push) and the "Done" report. Invoked only if Step 7 completed with a successful push.
+
+```markdown
+## Step 8 — Deployment Verification
+
+If `CLAUDE.md` contains a `## Deployment Targets` section, invoke `/verify-deployment`.
+
+Otherwise:
+- Scan project root for deployment signal files (railway.json, vercel.json, etc.)
+- If found: print a one-line nudge recommending /setup-deployment, but do not block
+- If not found: skip silently
+
+Outcomes from /verify-deployment:
+| Result | Action |
+|--------|--------|
+| All targets SUCCESS | Proceed to Done |
+| Any AUTH_FAILED | STOP — user must fix credentials; do not claim success |
+| Any TIMEOUT | STOP — report with dashboard URL; ask user "Check deployment manually? (y/n)" |
+| Any FAILED_MAX_ITERATIONS | STOP — point to tasks/deploy-report.md; do NOT claim session success |
+| Skipped (no targets for branch) | Proceed to Done |
+
+Opt-out: `/wrap-up-session --skip-deploy` bypasses Step 8 entirely (for WIP pushes).
+```
+
+Session summary gains a new line:
+
+```
+- Deployments: [Railway ✓ (1 attempt), Vercel ✓ (2 attempts)]
+```
+
+or on failure:
+
+```
+- Deployments: [Railway ✗ FAILED after 3 attempts — see tasks/deploy-report.md, Vercel ✓]
+```
+
+### 6. `session-start.sh` nudge
+
+If `CLAUDE.md` has no `## Deployment Targets` section but the project root contains any deployment signal file, print one line at session start:
+
+```
+⚠  Deploy signals detected (railway.json) but no Deployment Targets in CLAUDE.md.
+   Run /setup-deployment to enable automatic build verification.
+```
+
+Non-blocking. Suppressed if a `.claude/deploy-nudge-dismissed` marker file exists.
+
+### 7. Starter runbooks shipped with the template
+
+- `.claude/deployments/railway.md` — status_source: github-checks (Railway publishes check runs), CLI fallback via `railway status`
+- `.claude/deployments/vercel.md` — status_source: github-checks (Vercel publishes check runs), CLI fallback via `vercel inspect`
+- `.claude/deployments/README.md` — adapter contract documentation for authors adding new services
+
+## Files Involved
+
+- `CLAUDE.md` — add `## Deployment Targets` section template near the end; add `/setup-deployment` and `/verify-deployment` rows to the Skills table; update Workflow section to mention Step 8
+- `.claude/skills/verify-deployment/SKILL.md` — NEW
+- `.claude/skills/setup-deployment/SKILL.md` — NEW
+- `.claude/skills/wrap-up-session/SKILL.md` — insert Step 8; update session summary format in the Done banner
+- `.claude/deployments/README.md` — NEW (adapter contract)
+- `.claude/deployments/railway.md` — NEW starter runbook
+- `.claude/deployments/vercel.md` — NEW starter runbook
+- `.claude/hooks/session-start.sh` — add deploy-signal nudge
+- `.gitignore` — add `tasks/deploy-state.json`
+
+## Edge Cases
+
+- **No `## Deployment Targets` and no signal files** — `/verify-deployment` exits silently; wrap-up proceeds normally
+- **Signal files present but no section** — nudge printed once per session (wrap-up and session-start); never blocking
+- **Current branch doesn't match any target's trigger** — explicit skip message, exit clean
+- **Auth check fails** — fail fast before any polling; counts as escalation, not a retry
+- **Transient GitHub Checks API error** — retry the poll (network-level retry), not a fix iteration
+- **Build takes longer than timeout** — escalate with dashboard URL; user decides whether to wait longer manually
+- **Build succeeds on first try** — no fix loop; record and continue
+- **Code-debugger produces no diff** (can't fix it) — count as failed iteration, log reason, keep iterating until counter hits 3
+- **Fix iteration pushes a commit but the new build also fails on the same error** — iteration counter still advances; the hint set grows across iterations
+- **User force-pushes or amends during a fix loop** — next poll sees new SHA, abort state, warn user: "Commit SHA changed during deployment verification — aborting loop"
+- **Multiple check runs per service** (Vercel sometimes publishes more than one) — wait for all matching contexts to resolve; fail if any fails
+- **`/verify-deployment` invoked with uncommitted changes** — reject: "Uncommitted changes present. Commit before running /verify-deployment."
+- **Runbook frontmatter is malformed** — skip that target, report "<service>: malformed runbook", do not crash the whole verification
+- **`tasks/deploy-state.json` stale from a previous session** — ignored; state is scoped by commit SHA
+- **Project doesn't use GitHub** (local git only) — no check runs to poll; runbook must declare `status_source: cli` or verification is a no-op
+
+## Acceptance Criteria
+
+- [ ] `/verify-deployment` skill exists at `.claude/skills/verify-deployment/SKILL.md` with frontmatter and the flow described in Design §3
+- [ ] `/setup-deployment` skill exists at `.claude/skills/setup-deployment/SKILL.md` with the interactive bootstrap in Design §4
+- [ ] `.claude/deployments/README.md` documents the runbook frontmatter contract (required fields, status_source branches, common_failure_patterns format)
+- [ ] `.claude/deployments/railway.md` exists with valid frontmatter matching the contract
+- [ ] `.claude/deployments/vercel.md` exists with valid frontmatter matching the contract
+- [ ] `.claude/skills/wrap-up-session/SKILL.md` has a new Step 8 between current Step 7 and the Done report
+- [ ] Step 8 invokes `/verify-deployment` only when `## Deployment Targets` exists in `CLAUDE.md`
+- [ ] The Done banner format includes a `- Deployments:` line showing per-target status and attempt counts
+- [ ] `CLAUDE.md` has a `## Deployment Targets` section template (placeholder, not activated for this repo itself) and skill table entries for both new skills
+- [ ] `CLAUDE.md` Workflow section mentions Step 8 in the Wrap Up description
+- [ ] `.claude/hooks/session-start.sh` prints a deploy-signal nudge when applicable
+- [ ] `.gitignore` contains `tasks/deploy-state.json`
+- [ ] Fix loop is capped at 3 iterations with clear escalation when exhausted
+- [ ] Each fix iteration produces a NEW commit (never amend) with a message of the form `fix(deploy): ... [deploy-retry N/3]`
+- [ ] Auth check failure does not consume a fix-iteration slot
+- [ ] Runbook contract validation: missing required fields causes that target to be skipped with a report, not a crash
+- [ ] Opt-out `--skip-deploy` flag bypasses Step 8
+- [ ] No hardcoded "railway" or "vercel" string anywhere in `/verify-deployment` or `/wrap-up-session` — all service behavior flows from runbook frontmatter

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,26 +1,47 @@
 # Task Plan
 
-> Spec: specs/enforce-code-review.md
-> Status: Complete
+> Spec: specs/deployment-verification.md
+> Branch: claude/add-deployment-logs-AXX8x
+> Status: Pending user confirmation
 
 ---
 
-## Task 1 — Add severity classification output format to code-reviewer agent
+## Task 1 — Define the adapter contract (`.claude/deployments/README.md`)
 
-[x] Edit `.claude/agents/code-reviewer.md`: added `MUST-FIX` / `SHOULD-FIX` / `NITPICK` severity tags, classification rules, and structured output format
+[ ] TDD: README documents every required frontmatter field (`name`, `detect_files`, `status_source`, `auth_check_command`, `dashboard_url_template`), the two `status_source` values (`github-checks`, `cli`), conditional required fields per source, and the `common_failure_patterns` shape — verify by reading end-to-end against spec Design §2 -> Write `.claude/deployments/README.md` with the adapter contract, a worked example, and a "How to add a new service" section
 
-## Task 2 — Add severity classification to wrap-up review agent prompts (Step 4)
+## Task 2 — Ship the Railway starter runbook (`.claude/deployments/railway.md`)
 
-[x] Edit `.claude/skills/wrap-up-session/SKILL.md` Step 4: added severity classification section with tags, rules, and output format for all 4 agents
+[ ] TDD: Runbook has valid YAML frontmatter with `status_source: github-checks`, `check_contexts` list, `auth_check_command: railway whoami`, `cli_status_command` and `log_fetch_command` as fallback, at least 3 `common_failure_patterns`, and a troubleshooting body — verify by reading against the contract from Task 1 -> Write `.claude/deployments/railway.md`
 
-## Task 3 — Replace Step 5 reconciliation logic with enforcement tiers
+## Task 3 — Ship the Vercel starter runbook (`.claude/deployments/vercel.md`)
 
-[x] Edit `.claude/skills/wrap-up-session/SKILL.md` Step 5: replaced soft rules with severity-based enforcement (5.1), reconciliation table (5.2), and renumbered review-fix loop (5.3)
+[ ] TDD: Runbook has valid YAML frontmatter with `status_source: github-checks`, `check_contexts` for Vercel's preview and production deployments, `auth_check_command: vercel whoami`, `log_fetch_command` using `vercel inspect --logs`, at least 3 `common_failure_patterns`, and a troubleshooting body — verify by reading against the contract from Task 1 -> Write `.claude/deployments/vercel.md`
 
-## Task 4 — Add enforcement gates to Step 7 + update summary format
+## Task 4 — Write `/verify-deployment` skill (`.claude/skills/verify-deployment/SKILL.md`)
 
-[x] Edit `.claude/skills/wrap-up-session/SKILL.md` Step 7: added MUST-FIX and SHOULD-FIX gate conditions; updated session summary to show severity breakdown
+[ ] TDD: Skill file has YAML frontmatter (name, description, disable-model-invocation), steps covering (a) read CLAUDE.md targets section, (b) branch filter, (c) per-target auth check, (d) poll via GitHub Checks with CLI fallback, (e) fix-loop max 3 iterations with code-debugger delegation, (f) new-commit-per-iteration rule, (g) terminal-state escalation to `tasks/deploy-report.md`, (h) no hardcoded service names — verify against spec Design §3 end-to-end -> Create the directory and write `SKILL.md`
 
-## Task 5 — Verify consistency across all changes
+## Task 5 — Write `/setup-deployment` skill (`.claude/skills/setup-deployment/SKILL.md`)
 
-[x] Read both files end-to-end: severity terminology consistent, output format aligned, existing behavior preserved, no contradictions
+[ ] TDD: Skill file has YAML frontmatter and steps covering (a) scan for detect_files across all runbooks in `.claude/deployments/`, (b) interactive confirmation of detected services, (c) prompt for branch and project ID per service, (d) append or merge `## Deployment Targets` into `CLAUDE.md`, (e) copy missing runbooks from template, (f) add `tasks/deploy-state.json` to `.gitignore`, (g) final report — verify against spec Design §4 -> Create the directory and write `SKILL.md`
+
+## Task 6 — Add Step 8 to `/wrap-up-session`
+
+[ ] TDD: `wrap-up-session/SKILL.md` has a new `## Step 8 — Deployment Verification` section between current Step 7 and the Done report; Step 8 invokes `/verify-deployment` only when `## Deployment Targets` exists in CLAUDE.md, prints the nudge when signal files exist without the section, has a result table mapping each outcome to a Done/STOP action, supports `--skip-deploy` opt-out; Done banner gains a `- Deployments:` line with per-target status and attempt counts — verify by reading the modified file end-to-end against spec Design §5 -> Edit `.claude/skills/wrap-up-session/SKILL.md`
+
+## Task 7 — Update `CLAUDE.md`
+
+[ ] TDD: `CLAUDE.md` has (a) `/setup-deployment` and `/verify-deployment` rows added to the Skills table, (b) Workflow "Wrap Up" bullet mentions Step 8 deployment verification, (c) a new `## Deployment Targets` section template near the end with the table schema and config block from spec Design §1, (d) the section template is clearly marked as "example / populate via /setup-deployment" so it does NOT activate verification for the template repo itself — verify by reading the modified CLAUDE.md end-to-end -> Edit `/home/user/coding-agent-workflow/CLAUDE.md`
+
+## Task 8 — Add deploy-signal nudge to `session-start.sh`
+
+[ ] TDD: `.claude/hooks/session-start.sh` prints a single-line nudge when `CLAUDE.md` lacks a `## Deployment Targets` section AND any known deploy signal file exists (railway.json, railway.toml, vercel.json, .vercel/, netlify.toml, fly.toml, render.yaml); nudge is suppressed when `.claude/deploy-nudge-dismissed` exists; nudge is non-blocking (hook still exits 0) — verify by reading the hook script -> Edit `.claude/hooks/session-start.sh`
+
+## Task 9 — Add `tasks/deploy-state.json` to `.gitignore`
+
+[ ] TDD: `.gitignore` contains `tasks/deploy-state.json` (check it's not already ignored by a broader pattern) — verify by reading the file -> Edit `.gitignore`
+
+## Task 10 — End-to-end consistency review
+
+[ ] TDD: Walk the spec's acceptance criteria list and confirm each is satisfied across all changed files; confirm no file contains a hardcoded "railway" or "vercel" branching statement in logic (only as data in runbook filenames); confirm terminology is consistent (`target`, `runbook`, `iteration`, `fix-loop`, `check run`) across README, skills, and wrap-up; confirm the Done banner format is identical in spec and in wrap-up-session — verify by reading all modified files -> Fix any drift found

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -8,40 +8,46 @@
 
 ## Task 1 — Define the adapter contract (`.claude/deployments/README.md`)
 
-[ ] TDD: README documents every required frontmatter field (`name`, `detect_files`, `status_source`, `auth_check_command`, `dashboard_url_template`), the two `status_source` values (`github-checks`, `cli`), conditional required fields per source, and the `common_failure_patterns` shape — verify by reading end-to-end against spec Design §2 -> Write `.claude/deployments/README.md` with the adapter contract, a worked example, and a "How to add a new service" section
+[x] TDD: README documents every required frontmatter field (`name`, `detect_files`, `status_source`, `auth_check_command`, `dashboard_url_template`), the two `status_source` values (`github-checks`, `cli`), conditional required fields per source, and the `common_failure_patterns` shape — verify by reading end-to-end against spec Design §2 -> Write `.claude/deployments/README.md` with the adapter contract, a worked example, and a "How to add a new service" section
 
 ## Task 2 — Ship the Railway starter runbook (`.claude/deployments/railway.md`)
 
-[ ] TDD: Runbook has valid YAML frontmatter with `status_source: github-checks`, `check_contexts` list, `auth_check_command: railway whoami`, `cli_status_command` and `log_fetch_command` as fallback, at least 3 `common_failure_patterns`, and a troubleshooting body — verify by reading against the contract from Task 1 -> Write `.claude/deployments/railway.md`
+[x] TDD: Runbook has valid YAML frontmatter with `status_source: github-checks`, `check_contexts` list, `auth_check_command: railway whoami`, `cli_status_command` and `log_fetch_command` as fallback, at least 3 `common_failure_patterns`, and a troubleshooting body — verify by reading against the contract from Task 1 -> Write `.claude/deployments/railway.md`
 
 ## Task 3 — Ship the Vercel starter runbook (`.claude/deployments/vercel.md`)
 
-[ ] TDD: Runbook has valid YAML frontmatter with `status_source: github-checks`, `check_contexts` for Vercel's preview and production deployments, `auth_check_command: vercel whoami`, `log_fetch_command` using `vercel inspect --logs`, at least 3 `common_failure_patterns`, and a troubleshooting body — verify by reading against the contract from Task 1 -> Write `.claude/deployments/vercel.md`
+[x] TDD: Runbook has valid YAML frontmatter with `status_source: github-checks`, `check_contexts` for Vercel's preview and production deployments, `auth_check_command: vercel whoami`, `log_fetch_command` using `vercel inspect --logs`, at least 3 `common_failure_patterns`, and a troubleshooting body — verify by reading against the contract from Task 1 -> Write `.claude/deployments/vercel.md`
 
 ## Task 4 — Write `/verify-deployment` skill (`.claude/skills/verify-deployment/SKILL.md`)
 
-[ ] TDD: Skill file has YAML frontmatter (name, description, disable-model-invocation), steps covering (a) read CLAUDE.md targets section, (b) branch filter, (c) per-target auth check, (d) poll via GitHub Checks with CLI fallback, (e) fix-loop max 3 iterations with code-debugger delegation, (f) new-commit-per-iteration rule, (g) terminal-state escalation to `tasks/deploy-report.md`, (h) no hardcoded service names — verify against spec Design §3 end-to-end -> Create the directory and write `SKILL.md`
+[x] TDD: Skill file has YAML frontmatter (name, description, disable-model-invocation), steps covering (a) read CLAUDE.md targets section, (b) branch filter, (c) per-target auth check, (d) poll via GitHub Checks with CLI fallback, (e) fix-loop max 3 iterations with code-debugger delegation, (f) new-commit-per-iteration rule, (g) terminal-state escalation to `tasks/deploy-report.md`, (h) no hardcoded service names — verify against spec Design §3 end-to-end -> Create the directory and write `SKILL.md`
 
 ## Task 5 — Write `/setup-deployment` skill (`.claude/skills/setup-deployment/SKILL.md`)
 
-[ ] TDD: Skill file has YAML frontmatter and steps covering (a) scan for detect_files across all runbooks in `.claude/deployments/`, (b) interactive confirmation of detected services, (c) prompt for branch and project ID per service, (d) append or merge `## Deployment Targets` into `CLAUDE.md`, (e) copy missing runbooks from template, (f) add `tasks/deploy-state.json` to `.gitignore`, (g) final report — verify against spec Design §4 -> Create the directory and write `SKILL.md`
+[x] TDD: Skill file has YAML frontmatter and steps covering (a) scan for detect_files across all runbooks in `.claude/deployments/`, (b) interactive confirmation of detected services, (c) prompt for branch and project ID per service, (d) append or merge `## Deployment Targets` into `CLAUDE.md`, (e) copy missing runbooks from template, (f) add `tasks/deploy-state.json` to `.gitignore`, (g) final report — verify against spec Design §4 -> Create the directory and write `SKILL.md`
 
 ## Task 6 — Add Step 8 to `/wrap-up-session`
 
-[ ] TDD: `wrap-up-session/SKILL.md` has a new `## Step 8 — Deployment Verification` section between current Step 7 and the Done report; Step 8 invokes `/verify-deployment` only when `## Deployment Targets` exists in CLAUDE.md, prints the nudge when signal files exist without the section, has a result table mapping each outcome to a Done/STOP action, supports `--skip-deploy` opt-out; Done banner gains a `- Deployments:` line with per-target status and attempt counts — verify by reading the modified file end-to-end against spec Design §5 -> Edit `.claude/skills/wrap-up-session/SKILL.md`
+[x] TDD: `wrap-up-session/SKILL.md` has a new `## Step 8 — Deployment Verification` section between current Step 7 and the Done report; Step 8 invokes `/verify-deployment` only when `## Deployment Targets` exists in CLAUDE.md (strict-match regex), prints the nudge when signal files exist without the section, has a result table mapping each outcome to a Done/STOP action, supports `--skip-deploy` opt-out; Done banner gains a `- Deployments:` line with per-target status and attempt counts — verified by reading the modified file end-to-end against spec Design §5 -> Edit `.claude/skills/wrap-up-session/SKILL.md`
 
 ## Task 7 — Update `CLAUDE.md`
 
-[ ] TDD: `CLAUDE.md` has (a) `/setup-deployment` and `/verify-deployment` rows added to the Skills table, (b) Workflow "Wrap Up" bullet mentions Step 8 deployment verification, (c) a new `## Deployment Targets` section template near the end with the table schema and config block from spec Design §1, (d) the section template is clearly marked as "example / populate via /setup-deployment" so it does NOT activate verification for the template repo itself — verify by reading the modified CLAUDE.md end-to-end -> Edit `/home/user/coding-agent-workflow/CLAUDE.md`
+[x] TDD: `CLAUDE.md` has (a) `/setup-deployment` and `/verify-deployment` rows added to the Skills table, (b) Workflow "Wrap Up" bullet mentions Step 8 deployment verification, (c) an inactive Deployment Verification schema reference section near the end with table schema and config block, (d) the section heading is intentionally NOT the literal `## Deployment Targets` (verified by `grep -E '^## Deployment Targets[[:space:]]*$' CLAUDE.md` returning zero matches and the session-start hook running without nudge) — verified by reading the modified CLAUDE.md end-to-end and running the hook -> Edit `/home/user/coding-agent-workflow/CLAUDE.md`
 
 ## Task 8 — Add deploy-signal nudge to `session-start.sh`
 
-[ ] TDD: `.claude/hooks/session-start.sh` prints a single-line nudge when `CLAUDE.md` lacks a `## Deployment Targets` section AND any known deploy signal file exists (railway.json, railway.toml, vercel.json, .vercel/, netlify.toml, fly.toml, render.yaml); nudge is suppressed when `.claude/deploy-nudge-dismissed` exists; nudge is non-blocking (hook still exits 0) — verify by reading the hook script -> Edit `.claude/hooks/session-start.sh`
+[x] TDD: `.claude/hooks/session-start.sh` prints a single-line nudge when `CLAUDE.md` lacks a `## Deployment Targets` section AND any known deploy signal file exists (railway.json, railway.toml, vercel.json, .vercel/, netlify.toml, fly.toml, render.yaml); nudge is suppressed when `.claude/deploy-nudge-dismissed` exists; nudge is non-blocking (hook still exits 0) — verify by reading the hook script -> Edit `.claude/hooks/session-start.sh`
 
 ## Task 9 — Add `tasks/deploy-state.json` to `.gitignore`
 
-[ ] TDD: `.gitignore` contains `tasks/deploy-state.json` (check it's not already ignored by a broader pattern) — verify by reading the file -> Edit `.gitignore`
+[x] TDD: `.gitignore` contains `tasks/deploy-state.json` (check it's not already ignored by a broader pattern) — verify by reading the file -> Edit `.gitignore`
 
 ## Task 10 — End-to-end consistency review
 
-[ ] TDD: Walk the spec's acceptance criteria list and confirm each is satisfied across all changed files; confirm no file contains a hardcoded "railway" or "vercel" branching statement in logic (only as data in runbook filenames); confirm terminology is consistent (`target`, `runbook`, `iteration`, `fix-loop`, `check run`) across README, skills, and wrap-up; confirm the Done banner format is identical in spec and in wrap-up-session — verify by reading all modified files -> Fix any drift found
+[x] TDD: Walked spec acceptance criteria (all 18 satisfied), confirmed `/verify-deployment` and `/wrap-up-session` contain zero "railway"/"vercel" mentions (genericized 3 prose mentions in verify-deployment + 1 in wrap-up-session line 393), confirmed terminology consistency (target, runbook, iteration, check run all consistent; fix-loop/fix loop is acceptable English compound noun variation), confirmed Done banner format matches between spec and wrap-up-session — fixes applied: section heading collision in CLAUDE.md (used `## Deployment Verification — Schema Reference (Inactive Example)` heading, indented code block instead of fenced), strict-match grep in session-start.sh and verify-deployment skill instructions. Build verified by running session-start.sh hook (no nudge printed) and `grep -E '^## Deployment Targets[[:space:]]*$' CLAUDE.md` (zero matches)
+
+---
+
+## Build Status
+
+**All 10 tasks complete.** Implementation matches spec. Ready for user review or `/wrap-up-session`.


### PR DESCRIPTION
## Summary

Introduces a complete deployment verification layer that waits for post-push builds to resolve, fetches logs on failure, and loops a code-debugger fix cycle up to 3 iterations before escalating. The system is service-agnostic by design — all service-specific behavior is driven by runbook files in `.claude/deployments/`, making it trivial to add new deployment services without modifying core skills.

## Key Changes

- **New skill `/verify-deployment`** — Polls deployment services (Railway, Vercel, etc.) for build status after a push, fetches logs on failure, delegates fixes to `code-debugger`, commits each fix as a new commit, and loops up to 3 iterations before escalating with a detailed report.

- **New skill `/setup-deployment`** — One-time interactive bootstrap that scans the project for deployment signal files (railway.json, vercel.json, etc.), confirms detected services with the user, and writes the `## Deployment Targets` routing table into `CLAUDE.md`.

- **Adapter contract in `.claude/deployments/README.md`** — Documents the machine-readable frontmatter schema that every deployment service runbook must follow, including required fields (`name`, `detect_files`, `status_source`, `auth_check_command`, `dashboard_url_template`), conditional fields per status source, and the `common_failure_patterns` format for curated failure hints.

- **Starter runbooks** — Ships with Railway (`.claude/deployments/railway.md`) and Vercel (`.claude/deployments/vercel.md`) adapters, each with GitHub Checks polling, CLI fallbacks, auth checks, and 3+ curated failure patterns to guide the debugger.

- **Updated `/wrap-up-session`** — Adds Step 8 (Deployment Verification) that invokes `/verify-deployment` after a successful push. Session is not marked complete if any deployment target fails; supports `--skip-deploy` flag for WIP pushes.

- **Session-start nudge** — `.claude/hooks/session-start.sh` detects deployment signal files and prints a one-line nudge recommending `/setup-deployment` if no `## Deployment Targets` section exists (suppressible via `.claude/deploy-nudge-dismissed`).

- **State persistence** — `tasks/deploy-state.json` tracks per-service iteration counters and commit SHAs, allowing session resume to pick up where polling left off. Added to `.gitignore` along with `tasks/deploy-logs-*.log`.

- **Updated CLAUDE.md** — Documents the new deployment verification system, lists the two new skills, and notes that `/wrap-up-session` now includes deployment verification as Step 8.

## Implementation Details

- **Service-agnostic routing** — No deployment service names are hardcoded in skills. All routing is driven by the `## Deployment Targets` table in `CLAUDE.md` and the runbook files in `.claude/deployments/`. Adding a new service is a drop-in change: write a new runbook file with the required frontmatter, and it's immediately available to `/setup-deployment` and `/verify-deployment`.

- **Dual polling paths** — Supports both GitHub Checks API (primary, via `mcp__github__get_commit`) and per-service CLI commands (fallback). Runbooks declare which source to use via `status_source: github-checks | cli`.

- **Multi-context awareness** — Services like Vercel publish multiple check runs per commit (Preview + Production). The system waits for **all** matching contexts to succeed; a single failure on any context triggers the fix loop.

- **Transient error resilience** — Network failures and API 5xx errors are retried with exponential backoff at the polling layer and do not consume a fix iteration.

- **Curated failure hints** — Each runbook can declare `common_failure_patterns` (substring matches paired with actionable hints). Matching patterns are fed to the `code-debugger` agent to accelerate diagnosis.

- **Escalation with context** — After 3 failed iterations, generates `tasks/deploy-report.md` with iteration history, final logs, matched hints, dashboard URL, and suggested manual remediation steps (env vars, quotas, infra).

- **

https://claude.ai/code/session_01VX8RUTtgqMu1tGyaz8hFou