### PR TITLE
Add E2E verification gate and workflow quality improvements

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -27,6 +27,15 @@ Bridges the gap between `/plan` (design) and `/wrap-up-session` (close).
 5. Identify the project's test runner and build tooling (check `package.json`, `Makefile`, `pyproject.toml`, etc.)
 6. Run the full test suite once to establish a **green baseline**
    - If tests fail before you start: fix or flag to user before proceeding
+7. **Classify acceptance criteria** — for each AC in the spec, tag as `logic | integration | user-facing`. Store the classification in the build log so Phase 4 knows which need e2e evidence.
+
+   | AC type | Signals |
+   |---|---|
+   | `logic` | Pure functions, validators, transforms, utilities — no I/O |
+   | `integration` | API endpoints, DB queries, service-to-service calls, background jobs |
+   | `user-facing` | Auth flows, form submissions, navigation, UI state, anything a user sees or clicks |
+
+   When an AC mixes types, classify by the highest tier present (`user-facing` > `integration` > `logic`).
 
 ## Phase 1 — Task Execution (TDD Loop)
 
@@ -187,13 +196,32 @@ max_rounds: 3
 previous_failures: []
 ```
 
+### Evidence Required by AC Type
+
+Use the classification from Pre-Flight Step 7 to determine what evidence each AC needs:
+
+| AC type | Evidence required |
+|---|---|
+| `logic` | Unit test passes (covers the function in isolation) |
+| `integration` | Integration test passes (real API/DB/service interaction) |
+| `user-facing` | **E2E walkthrough via `/verify-e2e`** — entry exists in `tasks/e2e-log.md` for the current commit short-sha |
+
+If ANY AC is classified `user-facing`, you MUST invoke `/verify-e2e` before declaring Phase 4 complete. Unit coverage alone is insufficient for user-facing ACs — `/verify-e2e` runs a real browser through the real flow and writes evidence to `tasks/e2e-log.md`.
+
+Status marks distinguish evidence strength:
+
+- ✅ [criterion] — covered by unit or integration test `<name>`
+- ✅✅ [criterion] — covered by e2e walkthrough (see `tasks/e2e-log.md` entry for `<feature-name>` at `<short-sha>`)
+- ❌ [criterion] — [what's missing]
+
 **For each round:**
 
 1. Re-read `specs/[feature-name].md`
-2. Walk through each **Acceptance Criterion**:
-   - For each criterion: identify the test(s) that prove it
-   - Mark: `✅ [criterion]` or `❌ [criterion] — [what's missing]`
-3. **If all criteria are `✅`**: break → proceed to Phase 5
+2. For every AC classified `user-facing`, invoke `/verify-e2e` (skip if already invoked this round and e2e log shows a PASS entry for the current commit)
+3. Walk through each **Acceptance Criterion**:
+   - For each criterion: identify the evidence that proves it (test name OR e2e log entry)
+   - Mark using the status marks above
+4. **If all criteria are `✅` or `✅✅`**: break → proceed to Phase 5
 4. **If any criterion is `❌`**:
    a. Compare current failures against `previous_failures`
    b. **If SAME criteria failed as last round** → **HALT** (circular fix detected):

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -43,8 +43,27 @@ If working from a backlog item, use its description and the PRD context to pre-f
 
 Wait for complete answers before proceeding.
 
-### 2. Write the Spec
-Create `specs/[feature-name].md`:
+### 2. Write the Spec (MUST persist to disk)
+
+This step is not complete until both conditions hold:
+
+1. The file `specs/<feature-name>.md` exists on disk (verify with `ls specs/`)
+2. You have printed its **absolute path** in your message output
+
+**Forbidden:**
+- Presenting the spec inline as a code block without writing the file
+- Claiming the spec is "drafted" without a path to point to
+- Asking the user "should I save this?" — always save, then confirm location
+
+**Required output format at end of Step 2:**
+
+```
+✓ Spec written: /absolute/path/to/specs/<feature-name>.md
+```
+
+If you cannot write the file (permission error, directory missing), STOP and report the error — do not fall back to inline presentation.
+
+Spec template:
 
 ```markdown
 # Spec: [Feature Name]
@@ -72,8 +91,24 @@ Create `specs/[feature-name].md`:
 - `path/to/component.tsx` — [why]
 ```
 
-### 3. Write the Plan
-Write the task breakdown to `tasks/todo.md`:
+### 3. Write the Plan (MUST persist to disk)
+
+Same echo-or-fail pattern as Step 2 — applied to `tasks/todo.md`:
+
+1. The file `tasks/todo.md` exists on disk and contains the new `## Plan:` block (verify with `grep -F "## Plan:" tasks/todo.md`)
+2. You have printed its **absolute path** in your message output
+
+**Required output format at end of Step 3:**
+
+```
+✓ Plan written: /absolute/path/to/tasks/todo.md
+```
+
+**Forbidden:** presenting the plan inline only, batching plan + spec into a single "draft" without writing both files.
+
+If `tasks/todo.md` already exists with prior content, **append** the new `## Plan:` block — do not overwrite.
+
+Plan template:
 
 ```markdown
 ## Plan: [Feature Name]

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -72,6 +72,44 @@ Store the detected branch name — use `workflow/$WORKFLOW_BRANCH` in all subseq
 
 If using manual diff mode, use the `/tmp/coding-agent-workflow` clone as the source.
 
+### Step 2.5 — Legacy Directory Migration
+
+Older versions of this workflow shipped slash commands under `.claude/commands/`. The current layout uses `.claude/skills/`. Projects synced before the rename retain a stale `.claude/commands/` directory whose entries can shadow or contradict the canonical skills.
+
+Detect and resolve before showing diffs:
+
+1. Check whether `.claude/commands/` exists in the target project (`ls .claude/commands/ 2>/dev/null`)
+2. **If absent:** silent no-op — do not log anything, proceed to Step 3.
+3. **If present:** list its entries, then check for **overlapping basenames** with `.claude/skills/`:
+   - Build the set `commands_basenames = basename(file) without extension for file in .claude/commands/`
+   - Build the set `skills_basenames = basename(dir) for dir in .claude/skills/`
+   - Compute the intersection
+4. **If overlapping basenames exist:** surface the conflict list and refuse to auto-resolve:
+   ```
+   ⛔ Conflict: the following entries exist in BOTH .claude/commands/ and .claude/skills/:
+     - <basename1>
+     - <basename2>
+   These would shadow each other at runtime. Resolve manually before re-running /sync:
+     - Decide which version is authoritative (usually the skills/ version)
+     - Delete the obsolete copy
+     - Re-run /sync
+   ```
+   Do NOT prompt for archive/delete in this case — the user must intervene.
+5. **If no overlapping basenames:** prompt the user with three options:
+   ```
+   Legacy directory .claude/commands/ found with N entries.
+   The current workflow uses .claude/skills/ exclusively.
+   How should we handle the legacy directory?
+     [archive]  Rename to .claude/commands.legacy/ (preserves contents)
+     [delete]   Remove .claude/commands/ entirely
+     [skip]     Leave it in place for now (re-prompted next /sync)
+   Choose: archive / delete / skip
+   ```
+6. Apply the user's choice:
+   - `archive`: `mv .claude/commands .claude/commands.legacy`
+   - `delete`: `rm -rf .claude/commands` (confirm once more before running)
+   - `skip`: log "Legacy migration skipped — will re-prompt next /sync" and proceed
+
 ### Step 3 — Show What Changed
 
 Compare the syncable paths between the current project and the template source.

--- a/.claude/skills/verify-e2e/SKILL.md
+++ b/.claude/skills/verify-e2e/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: verify-e2e
+description: Force end-to-end browser validation of user-facing acceptance criteria before wrap-up. Use after /build when any AC describes user-facing behavior (auth flows, forms, navigation, UI state).
+disable-model-invocation: false
+---
+
+# /verify-e2e — End-to-End Walkthrough Gate
+
+Unit tests prove functions work. E2E walkthroughs prove features work.
+This skill forces the latter before a feature is allowed to ship.
+
+## When to Invoke
+
+- Automatically by `/build` Phase 4 when any AC is classified `user-facing`
+- Automatically by `/wrap-up-session` Step 6.3 when specs changed this session
+- Manually before claiming any feature with a UI or user flow is complete
+
+## Pre-Flight
+
+1. Read the active spec from `specs/` and extract **user-facing ACs**
+2. Verify the app is running locally (check dev server health endpoint, start via `/start-qa` if not)
+3. Verify the browser MCP is available (Playwright or Chrome)
+4. Load authentication state the way a real user would — cookie-based session, not injected tokens. For Supabase: use the `@supabase/ssr` cookie flow.
+
+## Walkthrough Protocol
+
+For each user-facing AC:
+
+1. **Describe the user journey** in plain language:
+   > "A new user lands on /signup, enters email + password, receives verification email, clicks link, lands on /dashboard logged in."
+
+2. **Execute each step in the real browser** via MCP tool calls:
+   - Navigate to URL
+   - Interact with real DOM (click, type, submit)
+   - Wait for real network responses
+   - Capture screenshot at each checkpoint
+
+3. **Assert observable state** at each step:
+   - URL matches expected route
+   - Required text/element is visible
+   - Network request succeeded with expected status
+   - No console errors
+
+4. **Negative path check**: run at least one failure variant per AC (wrong password, invalid email, missing permissions)
+
+## Evidence Format
+
+Append to `tasks/e2e-log.md` (create the file if it does not exist; do not commit it empty):
+
+```markdown
+## E2E Walkthrough — <Feature Name> — <YYYY-MM-DD> <short-sha>
+
+Spec: specs/<feature>.md
+Commit: <full-sha>
+
+### AC-1: <criterion text>
+Journey: <plain-language steps>
+Steps executed:
+  ✓ Navigate /signup → 200, form visible
+  ✓ Fill email=test@example.com, password=***
+  ✓ Submit → 302 to /verify-email
+  ✓ Click verification link → 200, redirect /dashboard
+  ✓ Assert session cookie set, user email displayed
+Negative: invalid email rejected with inline error ✓
+Screenshots: [paths]
+Result: PASS
+
+### AC-2: <criterion text>
+...
+```
+
+The log is **append-only**. Each invocation writes a new section keyed by feature name + commit short-sha. Never overwrite a prior walkthrough — they form the audit trail consumed by `/wrap-up-session` Step 6.3.
+
+## Failure Handling
+
+- **Step fails**: STOP the walkthrough, report the exact step + evidence, do not mark the AC complete. Hand back to `/build` or `/debug`.
+- **MCP browser unavailable**: STOP. Do not fall back to curl or unit tests. Report: "E2E gate cannot be satisfied without a browser MCP."
+- **Auth fails repeatedly**: STOP after 2 attempts. Do not retry with different credentials. Report to user and request guidance — this is usually a cookie/session misconfiguration, not a credential issue.
+- **Dev server unreachable**: STOP. Invoke `/start-qa` to bring it up, then resume. Do not assume it is "probably running."
+
+## Iron Laws
+
+1. **A real browser must load the real app.** No simulated DOM, no jsdom, no headless emulation that bypasses the network.
+2. **Authentication must go through the real login flow.** No token injection, no pre-seeded session cookies, no test-only auth backdoors.
+3. **Every user-facing AC gets its own walkthrough entry.** No batching ACs into a single composite entry.
+4. **A failed step halts the walkthrough.** Do not cascade to the next AC after a failure.
+5. **Evidence is the `tasks/e2e-log.md` entry with screenshots, not a summary claim.** If the log entry does not exist, the walkthrough did not happen.
+
+## Integration
+
+- **Invoked by**: `/build` Phase 4 (automatic for user-facing ACs), `/wrap-up-session` Step 6.3 (gate before push)
+- **Invokes**: `/start-qa` (to bring up the dev server if needed), `/debug` (on walkthrough failure)
+- **Writes**: `tasks/e2e-log.md` (append-only evidence log)
+- **Read by**: `/wrap-up-session` Step 6.3 (matches commit short-sha against e2e log entries)

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -82,6 +82,18 @@ Read `tasks/todo.md` and reconcile it against the actual state of the code:
 - Mark any completed items `[x]` that aren't already marked
 - Leave remaining items `[ ]`
 
+### Duplicate Plan Block Detection
+
+Before generating the session summary, scan `tasks/todo.md` for stale or duplicated content:
+
+1. **Duplicate `## Plan:` headings** — two or more headings with the same feature name. Merge them: promote any `[ ]` subtask that is unchecked in the older block but missing from the newer one, then remove the duplicate heading.
+2. **Orphan unchecked subtasks** — a `[ ]` item under a plan whose siblings are all `[x]`. Flag these to the user:
+   > _"Plan '<name>' has N unchecked subtasks while others are complete. Are these genuinely pending or should they be closed? (pending/close)"_
+3. **Stale plan blocks** — `## Plan:` blocks whose referenced spec file (`> Spec: specs/...`) no longer exists on disk. Flag for archival:
+   > _"Plan '<name>' references a missing spec '<path>'. Archive this plan block? (y/n)"_
+
+Do not proceed to the Idempotency Check while duplicates remain. Resolving them keeps the task register honest before a session summary is appended.
+
 ### Idempotency Check
 
 Generate a **session fingerprint** from the commit range: the short SHA of the first and last commit on this branch beyond `<base-branch>` (e.g., `a1b2c3f..d4e5f6a`). Include this fingerprint in the session summary header.
@@ -272,6 +284,23 @@ Run in order: lint/typecheck, unit tests, integration tests, e2e tests.
 
 ---
 
+## Step 6.3 — E2E Coverage Gate
+
+For every acceptance criterion in the specs touched this session (`git diff --name-only <base-branch>...HEAD -- specs/`):
+
+1. Re-classify each AC as `logic | integration | user-facing` using the same rules as `/build` Pre-Flight Step 7
+2. For each user-facing AC, confirm a `/verify-e2e` walkthrough ran during the session by checking `tasks/e2e-log.md` for an entry whose Spec line and Commit short-sha match the current commit range
+3. If any user-facing AC has no matching e2e log entry: **STOP** and ask:
+   > _"AC [ID] is user-facing but has no e2e walkthrough recorded in tasks/e2e-log.md. Run /verify-e2e now, or acknowledge the gap? (run/acknowledge)"_
+4. On `run`: invoke `/verify-e2e`, then re-check
+5. On `acknowledge`: record the gap in `tasks/lessons.md` under "E2E Gaps" with the AC ID and reason, then proceed. Do not silently skip.
+
+**If no specs were touched this session:** this gate is a silent no-op — proceed to Step 6.5.
+
+The e2e coverage gate exists because unit and integration tests pass while a user-facing flow can still be broken. The `/verify-e2e` log is the only evidence that a real browser walked the real flow against the current commit.
+
+---
+
 ## Step 6.5 — Worktree Integration (if applicable)
 
 If working in a git worktree (check with `git worktree list`):
@@ -429,6 +458,7 @@ Session wrapped up.
   - SHOULD-FIX: [N found, N fixed, N skipped]
   - NITPICK: [N found, skipped]
 - Tests: [PASS — suite name] or [FAIL — see above] or [SKIPPED — no test suite]
+- E2E coverage: [N user-facing ACs verified via /verify-e2e / NONE — no specs touched / GAP — N user-facing ACs acknowledged without e2e]
 - Pushed: [yes / no — reason] [user-approved if review gate was overridden]
 - Deployments: [<service> ✓ (N attempts), <service> ✓ (N attempts)] or [<service> ✗ FAILED after 3 attempts — see tasks/deploy-report.md, <service> ✓] or [SKIPPED — reason] or [NONE — no Deployment Targets configured]
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Run `/build` to execute the plan autonomously:
 
 ### 4. Wrap Up
 After any user correction: note the root cause in `tasks/lessons.md`.
+**Before** `/wrap-up-session`: if any acceptance criterion in the touched specs describes user-facing behavior, run `/verify-e2e` first. Unit tests alone do not close a user-flow AC. The wrap-up E2E Coverage Gate (Step 6.3) will halt and prompt if user-facing ACs lack a `tasks/e2e-log.md` entry for the current commit.
 At session end: run `/wrap-up-session` to sync learnings, tests, push, and **verify the deployment build** (Step 8). If the project has a `## Deployment Targets` section in this file, wrap-up will not claim success until the post-push build resolves green — looping a `code-debugger` fix cycle up to 3 times before escalating.
 
 ---
@@ -118,6 +119,7 @@ Invoke with `/skill-name` in the chat. Each skill is a directory under `.claude/
 | `/wrap-up-session` | Sync learnings, update task/bug registers, run tests, verify, merge worktree, push, **then verify deployment build (Step 8)** |
 | `/writing-skills` | Author new skills with proper structure, iron laws, and reference docs |
 | `/sync` | Pull latest skills, hooks, agents from the template repo into the current project |
+| `/verify-e2e` | Force end-to-end browser walkthrough of user-facing acceptance criteria; writes evidence to `tasks/e2e-log.md` |
 | `/folder-context-optimization` | Sweep a folder for legacy/unused files, propose archival |
 
 ---
@@ -154,11 +156,40 @@ Prefer editing existing files. Never skip git hooks. Keep commits atomic and des
 
 ---
 
+## Tool Preference Ladder
+
+Before reaching for a generic CLI, check this ladder. Using project-specific MCPs first avoids auth prompts, password walls, and flaky subprocess output.
+
+| Domain | Prefer | Over |
+|---|---|---|
+| Supabase DB / migrations / schema | `mcp__supabase__apply_migration`, `execute_sql`, `get_logs` | `supabase db push`, `psql` |
+| Vercel deploys / logs | `mcp__vercel__get_deployment_build_logs`, `get_runtime_logs` | `vercel logs` |
+| GitHub PRs / reviews / CI | `mcp__github__*` | `gh` CLI |
+| Library docs | `mcp__context7__resolve-library-id` → `get-library-docs` | Web search, guessing from memory |
+| Browser E2E validation | Playwright/Chrome MCP with real cookie-based auth | Headless `curl` + token injection |
+
+**Rule:** If a CLI asks for a password or fails auth twice, STOP and use the MCP. Do not guess credentials, do not retry with `--password` flags.
+
+---
+
+## Observability Discipline
+
+Recurring jobs (cron, smoke tests, health checks, `/loop` tasks) must follow **failure-only reporting**:
+
+- **Success path:** silent (exit 0, no log line, no notification)
+- **Failure path:** loud (structured error, actionable context, exit non-zero)
+- Never log "15/15 passed" every iteration — it trains the reader to ignore the channel
+
+If a passing run must be recorded, write it to a metrics sink (counter, gauge), not to a human-readable log or chat channel.
+
+---
+
 ## Quality Gate
 
 Before marking any task complete, confirm:
 - [ ] All relevant tests pass
 - [ ] New code has ≥80% test coverage
+- [ ] **Every user-facing acceptance criterion has an e2e walkthrough recorded in `tasks/e2e-log.md`** (see `/verify-e2e`)
 - [ ] No linting or type errors
 - [ ] Code passes Clean Code + SOLID review
 - [ ] No new security vulnerabilities

--- a/specs/workflow-insights-improvements.md
+++ b/specs/workflow-insights-improvements.md
@@ -1,0 +1,93 @@
+# Spec: Workflow Insights Improvements
+
+## Behavior
+
+Apply six targeted improvements to the coding-agent-workflow template, derived from a 78-session insights analysis on a downstream TypeScript/Next.js project. The improvements close gaps that caused premature completion claims, inline (non-persisted) specs, generic-CLI-before-MCP friction, and stale plan blocks. Each improvement is a documentation/configuration edit on existing markdown skill files plus one new skill file.
+
+## Inputs
+
+- Existing skill files: `.claude/skills/{plan,build,wrap-up-session,sync}/SKILL.md`
+- Existing rules file: `CLAUDE.md`
+- Insights report (analyzed in prior turn) identifying the friction patterns
+
+## Outputs
+
+- New file: `.claude/skills/verify-e2e/SKILL.md`
+- Modified: `.claude/skills/plan/SKILL.md` (Step 2 + Step 3 hard echo gate)
+- Modified: `.claude/skills/build/SKILL.md` (Phase 4 AC classification + e2e routing, Pre-Flight Step 6)
+- Modified: `.claude/skills/wrap-up-session/SKILL.md` (Step 2 duplicate sweep, new Step 6.3 e2e gate)
+- Modified: `.claude/skills/sync/SKILL.md` (legacy `.claude/commands/` migration step)
+- Modified: `CLAUDE.md` (Tool Preference Ladder, Observability Discipline, Quality Gate amendment, Wrap Up amendment)
+- New evidence log convention: `tasks/e2e-log.md` (created on first use by `/verify-e2e`, not committed empty)
+
+## Edge Cases
+
+- **Downstream project has no `.claude/commands/` dir** — `/sync` migration step must no-op silently.
+- **Downstream project has BOTH `.claude/commands/` and `.claude/skills/`** with overlapping names — `/sync` must surface the conflict, not auto-resolve.
+- **`/verify-e2e` invoked without a browser MCP available** — must STOP and report, not silently downgrade to unit tests.
+- **`/build` Phase 4 with all-logic ACs (no user-facing criteria)** — must NOT invoke `/verify-e2e`; e2e is conditional on classification.
+- **`/wrap-up-session` Step 6.3 with no specs touched this session** — gate becomes a silent no-op.
+- **`/plan` cannot write to `specs/`** (permission, missing dir) — must STOP and report, not fall back to inline.
+- **CLAUDE.md already has a `## Quality Gate` section in a downstream project that diverges** — amendment must use exact-match insertion to avoid clobbering.
+
+## Acceptance Criteria
+
+### AC-1 — `/verify-e2e` skill exists and is structurally valid
+- [ ] AC-1.1: File `.claude/skills/verify-e2e/SKILL.md` exists
+- [ ] AC-1.2: File contains valid YAML frontmatter with `name: verify-e2e`, a `description:`, and `disable-model-invocation: false`
+- [ ] AC-1.3: File documents Pre-Flight, Walkthrough Protocol, Evidence Format (writes `tasks/e2e-log.md`), Failure Handling, and Iron Laws sections
+- [ ] AC-1.4: Iron Laws explicitly forbid token injection, simulated DOM, and batching ACs
+- [ ] AC-1.5: Skill listed alongside other skills in `CLAUDE.md` Skills table
+
+### AC-2 — `/plan` enforces spec persistence
+- [ ] AC-2.1: `/plan` Step 2 contains the literal phrase "MUST persist to disk"
+- [ ] AC-2.2: Step 2 requires printing the absolute path in the form `✓ Spec written: /absolute/path/...`
+- [ ] AC-2.3: Step 2 explicitly forbids inline-only presentation
+- [ ] AC-2.4: Step 3 (plan write) has the same echo-or-fail pattern for `tasks/todo.md`
+
+### AC-3 — `/build` Phase 4 routes user-facing ACs through e2e
+- [ ] AC-3.1: Pre-Flight Checks include a new step that classifies every AC as `logic | integration | user-facing`
+- [ ] AC-3.2: Phase 4 contains a classification table mapping AC type to required evidence
+- [ ] AC-3.3: Phase 4 invokes `/verify-e2e` when any AC is classified `user-facing`
+- [ ] AC-3.4: Status marks distinguish `✅` (logic/integration) from `✅✅` (e2e walkthrough)
+
+### AC-4 — `/wrap-up-session` sweeps duplicates and gates on e2e coverage
+- [ ] AC-4.1: Step 2 contains a "Duplicate Plan Block Detection" subsection
+- [ ] AC-4.2: Detection covers (a) duplicate `## Plan:` headings, (b) orphan unchecked subtasks, (c) stale plan blocks whose spec file no longer exists
+- [ ] AC-4.3: New Step 6.3 "E2E Coverage Gate" exists between Step 6 and Step 6.5
+- [ ] AC-4.4: Step 6.3 STOPs and prompts the user when a user-facing AC has no `tasks/e2e-log.md` entry for the current commit range
+- [ ] AC-4.5: Done banner mentions e2e coverage status
+
+### AC-5 — `CLAUDE.md` adds tool ladder, observability, quality-gate row, wrap-up note
+- [ ] AC-5.1: New section `## Tool Preference Ladder` exists with rows for Supabase, Vercel, GitHub, Library Docs, Browser E2E
+- [ ] AC-5.2: Section contains the rule: "If a CLI asks for a password or fails auth twice, STOP and use the MCP"
+- [ ] AC-5.3: New section `## Observability Discipline` exists with the failure-only reporting rule
+- [ ] AC-5.4: `## Quality Gate` checklist contains a row about user-facing AC e2e walkthroughs
+- [ ] AC-5.5: `### 4. Wrap Up` section mentions running `/verify-e2e` before `/wrap-up-session` when applicable
+
+### AC-6 — `/sync` handles legacy `.claude/commands/` directory
+- [ ] AC-6.1: `/sync` Procedure has a new step (before "Show What Changed") titled "Legacy Directory Migration"
+- [ ] AC-6.2: Step detects presence of `.claude/commands/` in the target project
+- [ ] AC-6.3: When detected, prompts the user with options: archive (rename to `.claude/commands.legacy/`), delete, or skip
+- [ ] AC-6.4: When BOTH `.claude/commands/` and `.claude/skills/` contain entries with overlapping basenames, surfaces the conflict list and refuses to auto-resolve
+- [ ] AC-6.5: When `.claude/commands/` is absent, the step is a silent no-op (no log line)
+
+### AC-7 — Cross-cutting integrity
+- [ ] AC-7.1: `git diff` shows changes to exactly the 6 files listed under Outputs (plus the new `verify-e2e/SKILL.md`)
+- [ ] AC-7.2: No skill file is left with broken markdown structure (frontmatter intact, headings hierarchy preserved)
+- [ ] AC-7.3: All cross-references between skills resolve (e.g., `/build` referencing `/verify-e2e` matches the actual skill name)
+
+## Files Likely Involved
+
+- `.claude/skills/verify-e2e/SKILL.md` — NEW skill file
+- `.claude/skills/plan/SKILL.md` — Step 2 + Step 3 hard gate
+- `.claude/skills/build/SKILL.md` — Pre-Flight + Phase 4
+- `.claude/skills/wrap-up-session/SKILL.md` — Step 2 + new Step 6.3 + Done banner
+- `.claude/skills/sync/SKILL.md` — Legacy migration step
+- `CLAUDE.md` — Tool Ladder, Observability, Quality Gate, Wrap Up, Skills table
+
+## Out of Scope
+
+- Hooks to enforce the new rules (mentioned as secondary recommendations in analysis — separate spec)
+- Automated migration script for downstream projects (one-off; users will run `/sync` interactively)
+- Updating downstream project repos (this spec only modifies the template)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -61,62 +61,62 @@
 
 ### Task 1 — Create `/verify-e2e` skill (AC-1)
 
-[ ] VERIFY: `ls .claude/skills/verify-e2e/SKILL.md` exits 0 AND `head -5` shows YAML frontmatter with `name: verify-e2e` -> Create directory `.claude/skills/verify-e2e/` and write `SKILL.md` with sections: frontmatter, When to Invoke, Pre-Flight, Walkthrough Protocol, Evidence Format (writes `tasks/e2e-log.md`), Failure Handling, Iron Laws, Integration
+[x] VERIFY: `ls .claude/skills/verify-e2e/SKILL.md` exits 0 AND `head -5` shows YAML frontmatter with `name: verify-e2e` -> Create directory `.claude/skills/verify-e2e/` and write `SKILL.md` with sections: frontmatter, When to Invoke, Pre-Flight, Walkthrough Protocol, Evidence Format (writes `tasks/e2e-log.md`), Failure Handling, Iron Laws, Integration
 
-[ ] VERIFY: `grep -E "(token injection|simulated DOM|batching)" .claude/skills/verify-e2e/SKILL.md` returns 3+ matches across Iron Laws -> Ensure Iron Laws section explicitly forbids each
+[x] VERIFY: `grep -E "(token injection|simulated DOM|batching)" .claude/skills/verify-e2e/SKILL.md` returns 3+ matches across Iron Laws -> Ensure Iron Laws section explicitly forbids each
 
-[ ] VERIFY: `grep -E "verify-e2e" CLAUDE.md` returns a row in the Skills table -> Add `/verify-e2e` row to CLAUDE.md Skills table
+[x] VERIFY: `grep -E "verify-e2e" CLAUDE.md` returns a row in the Skills table -> Add `/verify-e2e` row to CLAUDE.md Skills table
 
 ### Task 2 — `/plan` spec-persistence hard gate (AC-2)
 
-[ ] VERIFY: `grep -F "MUST persist to disk" .claude/skills/plan/SKILL.md` returns 1 match in Step 2 -> Rewrite Step 2 with the hard echo-or-fail pattern
+[x] VERIFY: `grep -F "MUST persist to disk" .claude/skills/plan/SKILL.md` returns 1 match in Step 2 -> Rewrite Step 2 with the hard echo-or-fail pattern
 
-[ ] VERIFY: `grep -E "^✓ Spec written:" .claude/skills/plan/SKILL.md` AND `grep -E "Forbidden:" .claude/skills/plan/SKILL.md` both return matches -> Include the required output format and forbidden-actions block
+[x] VERIFY: `grep -E "^✓ Spec written:" .claude/skills/plan/SKILL.md` AND `grep -E "Forbidden:" .claude/skills/plan/SKILL.md` both return matches -> Include the required output format and forbidden-actions block
 
-[ ] VERIFY: `grep -F "MUST persist" .claude/skills/plan/SKILL.md` returns matches in BOTH Step 2 and Step 3 -> Apply same echo-or-fail pattern to Step 3 for `tasks/todo.md`
+[x] VERIFY: `grep -F "MUST persist" .claude/skills/plan/SKILL.md` returns matches in BOTH Step 2 and Step 3 -> Apply same echo-or-fail pattern to Step 3 for `tasks/todo.md`
 
 ### Task 3 — `/build` Phase 4 AC classification + e2e routing (AC-3)
 
-[ ] VERIFY: `grep -E "logic.*integration.*user-facing|user-facing.*logic" .claude/skills/build/SKILL.md` returns matches in BOTH Pre-Flight and Phase 4 -> Add new Pre-Flight Check step "Classify acceptance criteria"; modify Phase 4 to add classification table
+[x] VERIFY: `grep -E "logic.*integration.*user-facing|user-facing.*logic" .claude/skills/build/SKILL.md` returns matches in BOTH Pre-Flight and Phase 4 -> Add new Pre-Flight Check step "Classify acceptance criteria"; modify Phase 4 to add classification table
 
-[ ] VERIFY: `grep -F "/verify-e2e" .claude/skills/build/SKILL.md` returns at least 1 match in Phase 4 -> Phase 4 invokes `/verify-e2e` when any AC is `user-facing`
+[x] VERIFY: `grep -F "/verify-e2e" .claude/skills/build/SKILL.md` returns at least 1 match in Phase 4 -> Phase 4 invokes `/verify-e2e` when any AC is `user-facing`
 
-[ ] VERIFY: `grep -F "✅✅" .claude/skills/build/SKILL.md` returns at least 1 match -> Add the `✅✅` status mark for e2e-walkthrough-verified ACs
+[x] VERIFY: `grep -F "✅✅" .claude/skills/build/SKILL.md` returns at least 1 match -> Add the `✅✅` status mark for e2e-walkthrough-verified ACs
 
 ### Task 4 — `/wrap-up-session` duplicate sweep + Step 6.3 (AC-4)
 
-[ ] VERIFY: `grep -F "Duplicate Plan Block Detection" .claude/skills/wrap-up-session/SKILL.md` returns 1 match in Step 2 -> Add the subsection covering duplicate headings, orphan subtasks, stale plan blocks
+[x] VERIFY: `grep -F "Duplicate Plan Block Detection" .claude/skills/wrap-up-session/SKILL.md` returns 1 match in Step 2 -> Add the subsection covering duplicate headings, orphan subtasks, stale plan blocks
 
-[ ] VERIFY: `grep -E "^## Step 6.3" .claude/skills/wrap-up-session/SKILL.md` returns 1 match -> Insert new Step 6.3 "E2E Coverage Gate" between Step 6 and Step 6.5
+[x] VERIFY: `grep -E "^## Step 6.3" .claude/skills/wrap-up-session/SKILL.md` returns 1 match -> Insert new Step 6.3 "E2E Coverage Gate" between Step 6 and Step 6.5
 
-[ ] VERIFY: `grep -F "tasks/e2e-log.md" .claude/skills/wrap-up-session/SKILL.md` returns matches in Step 6.3 -> Step 6.3 references the e2e log as evidence source
+[x] VERIFY: `grep -F "tasks/e2e-log.md" .claude/skills/wrap-up-session/SKILL.md` returns matches in Step 6.3 -> Step 6.3 references the e2e log as evidence source
 
-[ ] VERIFY: `grep -E "e2e|E2E" .claude/skills/wrap-up-session/SKILL.md | grep -i "done\|banner\|coverage"` shows banner mention -> Update Done banner to include e2e coverage status
+[x] VERIFY: `grep -E "e2e|E2E" .claude/skills/wrap-up-session/SKILL.md | grep -i "done\|banner\|coverage"` shows banner mention -> Update Done banner to include e2e coverage status
 
 ### Task 5 — `CLAUDE.md` ladder + observability + quality gate + wrap-up (AC-5)
 
-[ ] VERIFY: `grep -E "^## Tool Preference Ladder" CLAUDE.md` returns 1 match AND `grep -F "fails auth twice" CLAUDE.md` returns 1 match -> Insert `## Tool Preference Ladder` section after Core Principles with table covering Supabase/Vercel/GitHub/Library Docs/Browser E2E and the password-twice-stop rule
+[x] VERIFY: `grep -E "^## Tool Preference Ladder" CLAUDE.md` returns 1 match AND `grep -F "fails auth twice" CLAUDE.md` returns 1 match -> Insert `## Tool Preference Ladder` section after Core Principles with table covering Supabase/Vercel/GitHub/Library Docs/Browser E2E and the password-twice-stop rule
 
-[ ] VERIFY: `grep -E "^## Observability Discipline" CLAUDE.md` returns 1 match AND `grep -F "failure-only reporting" CLAUDE.md` returns 1 match -> Insert `## Observability Discipline` section with the failure-only rule
+[x] VERIFY: `grep -E "^## Observability Discipline" CLAUDE.md` returns 1 match AND `grep -F "failure-only reporting" CLAUDE.md` returns 1 match -> Insert `## Observability Discipline` section with the failure-only rule
 
-[ ] VERIFY: `grep -F "user-facing acceptance criterion" CLAUDE.md` returns 1 match in `## Quality Gate` -> Add e2e walkthrough row to Quality Gate checklist
+[x] VERIFY: `grep -F "user-facing acceptance criterion" CLAUDE.md` returns 1 match in `## Quality Gate` -> Add e2e walkthrough row to Quality Gate checklist
 
-[ ] VERIFY: `grep -B2 -A5 "### 4. Wrap Up" CLAUDE.md | grep -F "/verify-e2e"` returns 1 match -> Amend Wrap Up section to mention `/verify-e2e` precondition
+[x] VERIFY: `grep -B2 -A5 "### 4. Wrap Up" CLAUDE.md | grep -F "/verify-e2e"` returns 1 match -> Amend Wrap Up section to mention `/verify-e2e` precondition
 
 ### Task 6 — `/sync` legacy `.claude/commands/` migration (AC-6)
 
-[ ] VERIFY: `grep -F "Legacy Directory Migration" .claude/skills/sync/SKILL.md` returns 1 match -> Insert new step before "Show What Changed" titled "Legacy Directory Migration"
+[x] VERIFY: `grep -F "Legacy Directory Migration" .claude/skills/sync/SKILL.md` returns 1 match -> Insert new step before "Show What Changed" titled "Legacy Directory Migration"
 
-[ ] VERIFY: `grep -E "archive|delete|skip" .claude/skills/sync/SKILL.md | wc -l` shows the three options documented -> Step prompts user with archive/delete/skip options when `.claude/commands/` exists
+[x] VERIFY: `grep -E "archive|delete|skip" .claude/skills/sync/SKILL.md | wc -l` shows the three options documented -> Step prompts user with archive/delete/skip options when `.claude/commands/` exists
 
-[ ] VERIFY: `grep -F "overlapping basenames" .claude/skills/sync/SKILL.md` returns 1 match -> Step surfaces conflict list when both dirs contain overlapping entries; refuses auto-resolve
+[x] VERIFY: `grep -F "overlapping basenames" .claude/skills/sync/SKILL.md` returns 1 match -> Step surfaces conflict list when both dirs contain overlapping entries; refuses auto-resolve
 
-[ ] VERIFY: `grep -F "silent no-op" .claude/skills/sync/SKILL.md` returns 1 match in the legacy migration step -> Step is silent no-op when `.claude/commands/` is absent
+[x] VERIFY: `grep -F "silent no-op" .claude/skills/sync/SKILL.md` returns 1 match in the legacy migration step -> Step is silent no-op when `.claude/commands/` is absent
 
 ### Task 7 — Cross-cutting integrity (AC-7)
 
-[ ] VERIFY: `git diff --name-only main...HEAD` lists exactly: `.claude/skills/verify-e2e/SKILL.md`, `.claude/skills/plan/SKILL.md`, `.claude/skills/build/SKILL.md`, `.claude/skills/wrap-up-session/SKILL.md`, `.claude/skills/sync/SKILL.md`, `CLAUDE.md`, `specs/workflow-insights-improvements.md`, `tasks/todo.md` -> Confirm scope did not leak into other files
+[x] VERIFY: `git diff --name-only main...HEAD` lists exactly: `.claude/skills/verify-e2e/SKILL.md`, `.claude/skills/plan/SKILL.md`, `.claude/skills/build/SKILL.md`, `.claude/skills/wrap-up-session/SKILL.md`, `.claude/skills/sync/SKILL.md`, `CLAUDE.md`, `specs/workflow-insights-improvements.md`, `tasks/todo.md` -> Confirm scope did not leak into other files
 
-[ ] VERIFY: For each modified SKILL.md, `head -6` shows valid frontmatter (`---` open, `name:`, `description:`, `disable-model-invocation:`, `---` close) -> Spot-check each file's frontmatter integrity
+[x] VERIFY: For each modified SKILL.md, `head -6` shows valid frontmatter (`---` open, `name:`, `description:`, `disable-model-invocation:`, `---` close) -> Spot-check each file's frontmatter integrity
 
-[ ] VERIFY: `grep -F "/verify-e2e" .claude/skills/build/SKILL.md .claude/skills/wrap-up-session/SKILL.md CLAUDE.md` returns matches in all three AND the skill name in `verify-e2e/SKILL.md` frontmatter matches exactly -> Cross-references resolve consistently
+[x] VERIFY: `grep -F "/verify-e2e" .claude/skills/build/SKILL.md .claude/skills/wrap-up-session/SKILL.md CLAUDE.md` returns matches in all three AND the skill name in `verify-e2e/SKILL.md` frontmatter matches exactly -> Cross-references resolve consistently

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -51,3 +51,72 @@
 ## Build Status
 
 **All 10 tasks complete.** Implementation matches spec. Ready for user review or `/wrap-up-session`.
+
+---
+
+## Plan: Workflow Insights Improvements
+> Spec: specs/workflow-insights-improvements.md
+> Branch: claude/analyze-session-insights-LGeul
+> Status: Pending user confirmation
+
+### Task 1 — Create `/verify-e2e` skill (AC-1)
+
+[ ] VERIFY: `ls .claude/skills/verify-e2e/SKILL.md` exits 0 AND `head -5` shows YAML frontmatter with `name: verify-e2e` -> Create directory `.claude/skills/verify-e2e/` and write `SKILL.md` with sections: frontmatter, When to Invoke, Pre-Flight, Walkthrough Protocol, Evidence Format (writes `tasks/e2e-log.md`), Failure Handling, Iron Laws, Integration
+
+[ ] VERIFY: `grep -E "(token injection|simulated DOM|batching)" .claude/skills/verify-e2e/SKILL.md` returns 3+ matches across Iron Laws -> Ensure Iron Laws section explicitly forbids each
+
+[ ] VERIFY: `grep -E "verify-e2e" CLAUDE.md` returns a row in the Skills table -> Add `/verify-e2e` row to CLAUDE.md Skills table
+
+### Task 2 — `/plan` spec-persistence hard gate (AC-2)
+
+[ ] VERIFY: `grep -F "MUST persist to disk" .claude/skills/plan/SKILL.md` returns 1 match in Step 2 -> Rewrite Step 2 with the hard echo-or-fail pattern
+
+[ ] VERIFY: `grep -E "^✓ Spec written:" .claude/skills/plan/SKILL.md` AND `grep -E "Forbidden:" .claude/skills/plan/SKILL.md` both return matches -> Include the required output format and forbidden-actions block
+
+[ ] VERIFY: `grep -F "MUST persist" .claude/skills/plan/SKILL.md` returns matches in BOTH Step 2 and Step 3 -> Apply same echo-or-fail pattern to Step 3 for `tasks/todo.md`
+
+### Task 3 — `/build` Phase 4 AC classification + e2e routing (AC-3)
+
+[ ] VERIFY: `grep -E "logic.*integration.*user-facing|user-facing.*logic" .claude/skills/build/SKILL.md` returns matches in BOTH Pre-Flight and Phase 4 -> Add new Pre-Flight Check step "Classify acceptance criteria"; modify Phase 4 to add classification table
+
+[ ] VERIFY: `grep -F "/verify-e2e" .claude/skills/build/SKILL.md` returns at least 1 match in Phase 4 -> Phase 4 invokes `/verify-e2e` when any AC is `user-facing`
+
+[ ] VERIFY: `grep -F "✅✅" .claude/skills/build/SKILL.md` returns at least 1 match -> Add the `✅✅` status mark for e2e-walkthrough-verified ACs
+
+### Task 4 — `/wrap-up-session` duplicate sweep + Step 6.3 (AC-4)
+
+[ ] VERIFY: `grep -F "Duplicate Plan Block Detection" .claude/skills/wrap-up-session/SKILL.md` returns 1 match in Step 2 -> Add the subsection covering duplicate headings, orphan subtasks, stale plan blocks
+
+[ ] VERIFY: `grep -E "^## Step 6.3" .claude/skills/wrap-up-session/SKILL.md` returns 1 match -> Insert new Step 6.3 "E2E Coverage Gate" between Step 6 and Step 6.5
+
+[ ] VERIFY: `grep -F "tasks/e2e-log.md" .claude/skills/wrap-up-session/SKILL.md` returns matches in Step 6.3 -> Step 6.3 references the e2e log as evidence source
+
+[ ] VERIFY: `grep -E "e2e|E2E" .claude/skills/wrap-up-session/SKILL.md | grep -i "done\|banner\|coverage"` shows banner mention -> Update Done banner to include e2e coverage status
+
+### Task 5 — `CLAUDE.md` ladder + observability + quality gate + wrap-up (AC-5)
+
+[ ] VERIFY: `grep -E "^## Tool Preference Ladder" CLAUDE.md` returns 1 match AND `grep -F "fails auth twice" CLAUDE.md` returns 1 match -> Insert `## Tool Preference Ladder` section after Core Principles with table covering Supabase/Vercel/GitHub/Library Docs/Browser E2E and the password-twice-stop rule
+
+[ ] VERIFY: `grep -E "^## Observability Discipline" CLAUDE.md` returns 1 match AND `grep -F "failure-only reporting" CLAUDE.md` returns 1 match -> Insert `## Observability Discipline` section with the failure-only rule
+
+[ ] VERIFY: `grep -F "user-facing acceptance criterion" CLAUDE.md` returns 1 match in `## Quality Gate` -> Add e2e walkthrough row to Quality Gate checklist
+
+[ ] VERIFY: `grep -B2 -A5 "### 4. Wrap Up" CLAUDE.md | grep -F "/verify-e2e"` returns 1 match -> Amend Wrap Up section to mention `/verify-e2e` precondition
+
+### Task 6 — `/sync` legacy `.claude/commands/` migration (AC-6)
+
+[ ] VERIFY: `grep -F "Legacy Directory Migration" .claude/skills/sync/SKILL.md` returns 1 match -> Insert new step before "Show What Changed" titled "Legacy Directory Migration"
+
+[ ] VERIFY: `grep -E "archive|delete|skip" .claude/skills/sync/SKILL.md | wc -l` shows the three options documented -> Step prompts user with archive/delete/skip options when `.claude/commands/` exists
+
+[ ] VERIFY: `grep -F "overlapping basenames" .claude/skills/sync/SKILL.md` returns 1 match -> Step surfaces conflict list when both dirs contain overlapping entries; refuses auto-resolve
+
+[ ] VERIFY: `grep -F "silent no-op" .claude/skills/sync/SKILL.md` returns 1 match in the legacy migration step -> Step is silent no-op when `.claude/commands/` is absent
+
+### Task 7 — Cross-cutting integrity (AC-7)
+
+[ ] VERIFY: `git diff --name-only main...HEAD` lists exactly: `.claude/skills/verify-e2e/SKILL.md`, `.claude/skills/plan/SKILL.md`, `.claude/skills/build/SKILL.md`, `.claude/skills/wrap-up-session/SKILL.md`, `.claude/skills/sync/SKILL.md`, `CLAUDE.md`, `specs/workflow-insights-improvements.md`, `tasks/todo.md` -> Confirm scope did not leak into other files
+
+[ ] VERIFY: For each modified SKILL.md, `head -6` shows valid frontmatter (`---` open, `name:`, `description:`, `disable-model-invocation:`, `---` close) -> Spot-check each file's frontmatter integrity
+
+[ ] VERIFY: `grep -F "/verify-e2e" .claude/skills/build/SKILL.md .claude/skills/wrap-up-session/SKILL.md CLAUDE.md` returns matches in all three AND the skill name in `verify-e2e/SKILL.md` frontmatter matches exactly -> Cross-references resolve consistently


### PR DESCRIPTION
## Summary

This PR introduces a new `/verify-e2e` skill and six targeted improvements to the coding-agent-workflow template, derived from insights analysis of 78 sessions on downstream projects. The changes close gaps that caused premature completion claims, inline-only specs, generic-CLI friction, and stale plan blocks.

## Key Changes

- **New skill: `/verify-e2e`** — Forces end-to-end browser validation of user-facing acceptance criteria before wrap-up. Writes append-only evidence to `tasks/e2e-log.md`. Includes Pre-Flight checks, Walkthrough Protocol, Evidence Format, Failure Handling, and Iron Laws (forbids token injection, simulated DOM, AC batching).

- **`/plan` spec-persistence hard gate** — Step 2 now requires writing `specs/<feature>.md` to disk and printing its absolute path. Step 3 applies the same echo-or-fail pattern to `tasks/todo.md`. Forbids inline-only presentation and "should I save?" prompts.

- **`/build` AC classification + e2e routing** — Pre-Flight Step 7 classifies every AC as `logic | integration | user-facing`. Phase 4 adds a classification table mapping AC type to required evidence. Invokes `/verify-e2e` when any AC is `user-facing`. Status marks distinguish `✅` (unit/integration test) from `✅✅` (e2e walkthrough).

- **`/wrap-up-session` duplicate sweep + Step 6.3 E2E Coverage Gate** — Step 2 adds "Duplicate Plan Block Detection" covering duplicate headings, orphan unchecked subtasks, and stale plan blocks. New Step 6.3 "E2E Coverage Gate" halts and prompts if any user-facing AC lacks a `tasks/e2e-log.md` entry for the current commit. Done banner now includes e2e coverage status.

- **`CLAUDE.md` tool ladder, observability, quality gate, wrap-up note** — New `## Tool Preference Ladder` section with rows for Supabase, Vercel, GitHub, Library Docs, Browser E2E, and the rule "If a CLI fails auth twice, STOP and use the MCP". New `## Observability Discipline` section with failure-only reporting rule. `## Quality Gate` checklist adds row for user-facing AC e2e walkthroughs. `### 4. Wrap Up` section mentions running `/verify-e2e` before `/wrap-up-session` when applicable. Skills table adds `/verify-e2e` entry.

- **`/sync` legacy `.claude/commands/` migration** — New Step 2.5 "Legacy Directory Migration" detects `.claude/commands/` in target projects. When absent: silent no-op. When present with no overlapping basenames: prompts user with archive/delete/skip options. When overlapping basenames exist: surfaces conflict list and refuses auto-resolve.

- **Spec and task register** — New `specs/workflow-insights-improvements.md` documents the feature with 7 acceptance criteria (AC-1 through AC-7) covering structural validity, spec persistence, AC classification, duplicate detection, tool ladder, legacy migration, and cross-cutting integrity. `tasks/todo.md` appended with a new Plan block tracking all 7 tasks with verification steps.

## Notable Implementation Details

- E2E evidence is append-only and keyed by feature name + commit short-sha, forming an audit trail consumed by `/wrap-up-session` Step 6.3.
- AC classification uses a three-tier hierarchy: `user-facing` > `integration` > `logic`. Mixed-type ACs are classified by the highest tier present.
- The `/sync` legacy migration step is a silent no-op when `.claude/commands/` is absent, avoiding noise in projects already on the new layout.
- All cross-references between skills are consistent (e.g., `/build` Phase 4 references `/verify-e2e` by exact skill name).
- No skill file is left with broken markdown structure; frontmatter and heading hierarchy are preserved.

https://claude.ai/code/session_01E1kTH3Ut1WNEXK4d5x3bGG