### PR TITLE
Add automatic workflow template drift detection

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -85,6 +85,62 @@ if [ ! -f ".claude/deploy-nudge-dismissed" ] && [ -f "CLAUDE.md" ]; then
   fi
 fi
 
+# ── Workflow Template Drift Check ────────────────────────────────────────────
+# Notifies if the coding-agent-workflow template has new commits affecting
+# syncable paths (.claude/skills, .claude/agents, .claude/hooks, settings.json).
+# Silent when in sync (observability discipline: loud only on actionable state).
+#
+# Preconditions:
+#   - A git remote named 'workflow' must exist (skipped otherwise)
+#   - Not dismissed via .claude/sync-check-dismissed
+#
+# Behaviour:
+#   - Fetches at most once per 24h (cached in .claude/.sync-check-cache)
+#   - 5s network timeout — never hangs the session if offline
+#   - Reports drift count; user runs /sync to review & apply
+WORKFLOW_CHECK_CACHE=".claude/.sync-check-cache"
+WORKFLOW_CHECK_MAX_AGE=86400  # 24 hours
+
+if [ ! -f ".claude/sync-check-dismissed" ] \
+   && git rev-parse --is-inside-work-tree &>/dev/null \
+   && git remote get-url workflow &>/dev/null; then
+
+  NEED_FETCH=1
+  if [ -f "$WORKFLOW_CHECK_CACHE" ]; then
+    CACHE_MTIME=$(stat -c %Y "$WORKFLOW_CHECK_CACHE" 2>/dev/null \
+                  || stat -f %m "$WORKFLOW_CHECK_CACHE" 2>/dev/null \
+                  || echo 0)
+    CACHE_AGE=$(( $(date +%s) - CACHE_MTIME ))
+    [ "$CACHE_AGE" -lt "$WORKFLOW_CHECK_MAX_AGE" ] && NEED_FETCH=0
+  fi
+
+  DRIFT_COUNT=0
+  WORKFLOW_BRANCH=""
+
+  if [ "$NEED_FETCH" = "1" ]; then
+    WORKFLOW_BRANCH=$(git ls-remote --symref workflow HEAD 2>/dev/null \
+      | awk '/^ref:/ {sub("refs/heads/","",$2); print $2; exit}')
+    WORKFLOW_BRANCH=${WORKFLOW_BRANCH:-main}
+
+    if timeout 5 git fetch workflow "$WORKFLOW_BRANCH" &>/dev/null; then
+      DRIFT_COUNT=$(git diff --name-only "workflow/$WORKFLOW_BRANCH" -- \
+        .claude/skills .claude/agents .claude/hooks .claude/settings.json 2>/dev/null \
+        | wc -l | tr -d ' ')
+      printf '%s\n%s\n' "$DRIFT_COUNT" "$WORKFLOW_BRANCH" > "$WORKFLOW_CHECK_CACHE"
+    fi
+  else
+    DRIFT_COUNT=$(sed -n '1p' "$WORKFLOW_CHECK_CACHE" 2>/dev/null || echo 0)
+    WORKFLOW_BRANCH=$(sed -n '2p' "$WORKFLOW_CHECK_CACHE" 2>/dev/null)
+    WORKFLOW_BRANCH=${WORKFLOW_BRANCH:-main}
+  fi
+
+  if [ "${DRIFT_COUNT:-0}" -gt 0 ]; then
+    echo ""
+    echo "🔄  TEMPLATE DRIFT — $DRIFT_COUNT file(s) differ from workflow/$WORKFLOW_BRANCH"
+    echo "    Run /sync to review and apply updates (or 'touch .claude/sync-check-dismissed' to silence)."
+  fi
+fi
+
 # ── Available Skills ────────────────────────────────────────────────────────
 echo ""
 echo "SKILLS AVAILABLE"

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -13,6 +13,35 @@ Pull the latest skills, hooks, agents, and config from the `coding-agent-workflo
 - **GitHub**: `Joaovsales/coding-agent-workflow`
 - **Remote name convention**: `workflow`
 
+## Automatic Drift Notification
+
+The `session-start.sh` hook checks the `workflow` remote once per 24h and prints a
+one-line `🔄 TEMPLATE DRIFT` notice at session start when syncable paths differ
+from `workflow/<default-branch>`. It does **not** modify files — it only nudges
+you to run `/sync`.
+
+**Enable on a fresh project:**
+
+```bash
+git remote add workflow https://github.com/Joaovsales/coding-agent-workflow.git
+```
+
+Once the remote exists, the hook takes over automatically. Fetch is capped at a
+5-second timeout (offline sessions stay silent). Cache lives at
+`.claude/.sync-check-cache` (gitignored).
+
+**Silence the notification:**
+
+```bash
+touch .claude/sync-check-dismissed
+```
+
+**Force a re-check now** (bypass the 24h cache):
+
+```bash
+rm .claude/.sync-check-cache
+```
+
 ## Syncable Paths
 
 These are the files/directories managed by the workflow template:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Deployment verification state — per-session, not committed
 tasks/deploy-state.json
+
+# Session-start template drift-check cache (per-clone, not committed)
+.claude/.sync-check-cache
+.claude/sync-check-dismissed


### PR DESCRIPTION
## Summary

Implements automatic drift detection for the coding-agent-workflow template, notifying users when syncable paths diverge from the upstream template without modifying files or blocking session startup.

## Key Changes

- **Workflow drift check in session-start.sh**: Added a new check that runs once per 24 hours (cached) to detect when `.claude/skills`, `.claude/agents`, `.claude/hooks`, and `settings.json` differ from the upstream `workflow` remote. The check:
  - Only runs if a `workflow` git remote exists
  - Enforces a 5-second network timeout to prevent hanging offline sessions
  - Caches results for 24 hours to minimize repeated fetches
  - Displays a single-line notification (`🔄 TEMPLATE DRIFT`) only when drift is detected
  - Can be dismissed via `.claude/sync-check-dismissed` or bypassed by removing the cache file

- **Updated sync skill documentation**: Added a new "Automatic Drift Notification" section explaining:
  - How the automatic check works
  - Setup instructions for fresh projects
  - How to silence or force re-check the notification

- **Updated .gitignore**: Added entries for the drift-check cache (`.claude/.sync-check-cache`) and dismissal flag (`.claude/sync-check-dismissed`) to prevent committing per-clone state

## Implementation Details

- Uses `git ls-remote` to detect the default branch without requiring a full fetch
- Caches both drift count and branch name to avoid repeated remote queries
- Implements cross-platform `stat` compatibility (GNU/BSD variants)
- Silent by default when in sync (observability discipline: only notify on actionable state)
- Users run `/sync` to review and apply updates after seeing the notification

https://claude.ai/code/session_01XuPU9h52TthKipj6ERQuRs