### PR TITLE
feat: harden workflow against insights friction patterns

### DIFF
--- a/.claude/hooks/cron-quiet-hours.sh
+++ b/.claude/hooks/cron-quiet-hours.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# cron-quiet-hours.sh — library for cron-driven smoke tests / health checks.
+#
+# Usage in your cron script:
+#
+#   #!/bin/bash
+#   source "$(dirname "$0")/../.claude/hooks/cron-quiet-hours.sh"
+#   if cron_should_suppress; then
+#     # Active Claude session — write metrics only, no human-readable log.
+#     record_metric "smoke_test_result" "$result"
+#     exit 0
+#   fi
+#   # Normal noisy path (e.g., post to Slack on failure, echo to log on success).
+#
+# The active-session sentinel is created by session-start.sh and removed by
+# session-stop.sh. Missing sentinel → no active session → cron runs normally.
+#
+# Honors CRON_QUIET_OVERRIDE=1 to force noisy reporting (useful for on-call
+# triage when you WANT notifications even during an active session).
+
+SENTINEL="${CLAUDE_SESSION_SENTINEL:-/tmp/claude-code-session-active}"
+
+cron_should_suppress() {
+  [ "${CRON_QUIET_OVERRIDE:-0}" = "1" ] && return 1
+  [ -f "$SENTINEL" ]
+}
+
+# Failure-only reporting helper per the project's Observability Discipline.
+# Pass exit code + message. Success = silent. Failure = stderr + non-zero exit.
+report_failure_only() {
+  local code="$1"; shift
+  local msg="$*"
+  if [ "$code" -ne 0 ]; then
+    if cron_should_suppress; then
+      # Session is active — write to metrics sink only.
+      metric_dir="${CLAUDE_METRICS_DIR:-/tmp/claude-metrics}"
+      mkdir -p "$metric_dir"
+      printf '%s\tFAIL\t%s\n' "$(date -u +%FT%TZ)" "$msg" >> "$metric_dir/cron.tsv"
+    else
+      echo "FAIL: $msg" >&2
+    fi
+    return "$code"
+  fi
+  # Success: silent. Never log "all good" every iteration.
+  return 0
+}

--- a/.claude/hooks/pre-push-guard.sh
+++ b/.claude/hooks/pre-push-guard.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Pre-push guard — invoked as a PreToolUse hook on Bash calls.
+# Purpose:
+#   1. When the command is `git push`, run typecheck + lint before allowing the push.
+#   2. When the command is a "done"-signaling echo/reply (best-effort match), warn
+#      the main agent if local commits have not been pushed to the tracked remote.
+#
+# Kill switch: SKIP_PREPUSH_GUARD=1
+#
+# Exit codes:
+#   0      — allow the tool call
+#   non-0  — block the tool call (Claude Code surfaces stderr back to the agent)
+
+set -uo pipefail
+
+[ "${SKIP_PREPUSH_GUARD:-0}" = "1" ] && exit 0
+
+# Claude Code passes hook input as JSON on stdin. We extract the command.
+# Fall back to empty string if jq is unavailable or input is not JSON.
+INPUT=$(cat 2>/dev/null || true)
+CMD=""
+if command -v jq >/dev/null 2>&1; then
+  CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+fi
+
+# Fallback: treat raw stdin as the command if jq parse failed.
+[ -z "$CMD" ] && CMD="$INPUT"
+
+# Normalize whitespace for matching.
+CMD_TRIM=$(printf '%s' "$CMD" | tr '\n' ' ' | sed -E 's/[[:space:]]+/ /g')
+
+# ── Gate 1: typecheck + lint before git push ─────────────────────────────────
+if printf '%s' "$CMD_TRIM" | grep -Eq '^(.*&& *)?git +push( |$)'; then
+  # Allow --force push bypass ONLY if the user explicitly set ALLOW_FORCE_PUSH=1.
+  if printf '%s' "$CMD_TRIM" | grep -Eq 'git +push[^#]*(--force|-f)( |$)'; then
+    if [ "${ALLOW_FORCE_PUSH:-0}" != "1" ]; then
+      echo "BLOCKED: force push detected. Set ALLOW_FORCE_PUSH=1 to override." >&2
+      exit 2
+    fi
+  fi
+
+  # Run typecheck + lint if package.json declares them. Silent no-op otherwise.
+  if [ -f package.json ] && command -v jq >/dev/null 2>&1; then
+    SCRIPTS=$(jq -r '.scripts // {} | keys[]' package.json 2>/dev/null || true)
+    for script in typecheck lint; do
+      if printf '%s\n' "$SCRIPTS" | grep -qx "$script"; then
+        if ! npm run --silent "$script" >/tmp/prepush-"$script".log 2>&1; then
+          echo "BLOCKED: \`npm run $script\` failed before push. See /tmp/prepush-${script}.log" >&2
+          tail -30 /tmp/prepush-"$script".log >&2
+          exit 2
+        fi
+      fi
+    done
+  fi
+fi
+
+# ── Gate 2: warn on unpushed commits when the agent signals completion ───────
+# Best-effort detection of "done"-claims in shell output (e.g., `echo "Done"`).
+# We only WARN here (exit 0 with stderr message) — we cannot reliably block
+# textual replies, and the real enforcement lives in wrap-up-session.
+if printf '%s' "$CMD_TRIM" | grep -Eiq '(echo|printf).*(wrapped up|session done|all done|shipped|pushed)'; then
+  if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+    if [ -n "$BRANCH" ]; then
+      UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null || echo "")
+      if [ -n "$UPSTREAM" ]; then
+        AHEAD=$(git rev-list --count "$UPSTREAM"..HEAD 2>/dev/null || echo 0)
+        if [ "${AHEAD:-0}" -gt 0 ]; then
+          echo "WARNING: $AHEAD local commit(s) on $BRANCH not pushed to $UPSTREAM." >&2
+          echo "         Do not claim 'done' — run \`git push\` first." >&2
+        fi
+      else
+        echo "WARNING: branch $BRANCH has no upstream. Did you forget \`git push -u origin $BRANCH\`?" >&2
+      fi
+    fi
+  fi
+fi
+
+exit 0

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -8,6 +8,13 @@ set -euo pipefail
 # Kill switch: skip hook if SKIP_SESSION_START=1
 [ "${SKIP_SESSION_START:-0}" = "1" ] && exit 0
 
+# ── Active-session sentinel ──────────────────────────────────────────────────
+# Written here, removed by session-stop.sh. Cron jobs that source
+# cron-quiet-hours.sh use its presence to suppress human-readable reporting
+# during active sessions (failure-only path in observability discipline).
+SENTINEL="${CLAUDE_SESSION_SENTINEL:-/tmp/claude-code-session-active}"
+printf 'pid=%s\nstarted=%s\nrepo=%s\n' "$$" "$(date -u +%FT%TZ)" "$(pwd)" > "$SENTINEL" 2>/dev/null || true
+
 DIVIDER="════════════════════════════════════════"
 
 echo ""

--- a/.claude/hooks/session-stop.sh
+++ b/.claude/hooks/session-stop.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Session Stop hook — runs when a Claude Code session ends.
+# Responsibilities:
+#   1. Remove the session-active sentinel so cron jobs resume normal reporting.
+#   2. Warn if the session ends with local commits not pushed to upstream.
+#
+# Kill switch: SKIP_SESSION_STOP=1
+
+set -uo pipefail
+[ "${SKIP_SESSION_STOP:-0}" = "1" ] && exit 0
+
+SENTINEL="${CLAUDE_SESSION_SENTINEL:-/tmp/claude-code-session-active}"
+
+# ── 1. Clear sentinel ────────────────────────────────────────────────────────
+[ -f "$SENTINEL" ] && rm -f "$SENTINEL"
+
+# ── 2. Unpushed-commit warning ───────────────────────────────────────────────
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  BRANCH=$(git branch --show-current 2>/dev/null || echo "")
+  if [ -n "$BRANCH" ]; then
+    UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null || echo "")
+    if [ -n "$UPSTREAM" ]; then
+      AHEAD=$(git rev-list --count "$UPSTREAM"..HEAD 2>/dev/null || echo 0)
+      if [ "${AHEAD:-0}" -gt 0 ]; then
+        echo ""
+        echo "⚠  SESSION END: $AHEAD unpushed commit(s) on $BRANCH → $UPSTREAM"
+        echo "   Run: git push -u origin $BRANCH"
+      fi
+    else
+      DIRTY=$(git status --short 2>/dev/null | wc -l | tr -d ' ')
+      LOCAL_COMMITS=$(git log --oneline 2>/dev/null | wc -l | tr -d ' ')
+      if [ "${LOCAL_COMMITS:-0}" -gt 0 ] && [ "${DIRTY:-0}" -eq 0 ]; then
+        echo ""
+        echo "⚠  SESSION END: branch $BRANCH has no upstream."
+        echo "   Run: git push -u origin $BRANCH"
+      fi
+    fi
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,17 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/pre-push-guard.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Bash",
@@ -17,6 +28,16 @@
           {
             "type": "command",
             "command": "bash .claude/hooks/auto-test-runner.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/session-stop.sh"
           }
         ]
       }

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -208,6 +208,8 @@ Use the classification from Pre-Flight Step 7 to determine what evidence each AC
 
 If ANY AC is classified `user-facing`, you MUST invoke `/verify-e2e` before declaring Phase 4 complete. Unit coverage alone is insufficient for user-facing ACs — `/verify-e2e` runs a real browser through the real flow and writes evidence to `tasks/e2e-log.md`.
 
+**Non-skippable**: The Build Report is blocked until every user-facing AC shows a `✅✅` mark referencing a `tasks/e2e-log.md` entry whose commit short-sha matches the current HEAD. "Form renders in jsdom" / "unit test passes" / "spot-checked manually" are NOT substitutes. If `/verify-e2e` cannot run (no browser available, auth missing), HALT and escalate — do not fall back to unit evidence for a user-facing AC.
+
 Status marks distinguish evidence strength:
 
 - ✅ [criterion] — covered by unit or integration test `<name>`
@@ -248,9 +250,19 @@ If `tasks/backlog.md` exists:
 2. Mark the item as `[x]` in `tasks/backlog.md`
 3. Update `tasks/project-context.md` `[CURRENT-PHASE]` section if the phase is now complete (all items `[x]`)
 
-## Phase 6 — Build Report
+## Phase 6 — Build Report (MUST include persistence echo)
 
-Output the final report to the user:
+The build is not "done" until you have proven what is on disk. End your turn with
+the report below, populated from **real command output**, not recollection.
+
+### Required persistence proofs (run these, paste their output)
+
+1. `git status --short`            — shows uncommitted changes (if any)
+2. `git log --oneline <base>..HEAD` — shows commits created this build
+3. `ls specs/ | grep <feature>`    — confirms spec is on disk
+4. `grep -c '^\[x\]' tasks/todo.md` vs `grep -c '^\[ \]' tasks/todo.md`
+
+Then output:
 
 ```
 ══════════════════════════════════════
@@ -262,17 +274,35 @@ Output the final report to the user:
 📐 Spec Validation: [all criteria met / N gaps remain]
 🧹 Simplify: [N improvements applied]
 
-Files Changed:
-  [git diff --stat summary]
+Files on disk (persistence proof):
+  ✓ Spec: /absolute/path/to/specs/<feature-name>.md
+  ✓ Plan: /absolute/path/to/tasks/todo.md
+  ✓ Source changes: [git diff --stat summary — paste actual output]
+
+Git state:
+  Branch: <branch>
+  Commits this build: [N]  (paste `git log --oneline <base>..HEAD` output)
+  Uncommitted changes: [Y/N — paste `git status --short` if non-empty]
+  Pushed: [NOT YET — /build does not push. /wrap-up-session handles push.]
 
 Acceptance Criteria:
-  ✅ [criterion 1]
-  ✅ [criterion 2]
+  ✅✅ [user-facing criterion — e2e log entry: tasks/e2e-log.md @ <short-sha>]
+  ✅   [logic/integration criterion — test: <test-name>]
   ...
 
-Ready for /wrap-up-session or manual QA.
+Next: /wrap-up-session (runs reviews, tests, commits, pushes).
 ══════════════════════════════════════
 ```
+
+### Forbidden completion patterns
+
+- Claiming "build complete" without the persistence proof block above
+- Stating a file was "created" or "updated" without showing its absolute path
+- Omitting the `Pushed:` line (even to say "NOT YET" — it must be explicit)
+- Using past-tense verbs ("I wrote", "I saved") with no corresponding command output
+
+If any required proof command fails or returns empty, STOP and investigate.
+Do not emit the Build Report.
 
 ## Error Handling
 

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -12,10 +12,14 @@ Systematically investigate and fix bugs using root cause analysis, the `code-deb
 ## The Iron Law
 
 ```
-NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+NO FIXES WITHOUT THE ROOT-CAUSE PRELUDE (Phase 0.5) AND REPRODUCTION (Phase 1)
 ```
 
-If you haven't completed Phase 1 (Reproduce & Isolate), you cannot propose fixes. Symptom fixes are failure.
+You cannot propose fixes until:
+1. The **Root-Cause Prelude** (Phase 0.5) has listed 3 candidates and picked one based on disconfirming evidence, AND
+2. Phase 1 (Reproduce & Isolate) has produced a minimal failing reproduction.
+
+Symptom fixes are failure. Single-hypothesis tunnel vision is failure.
 
 ## Pre-Flight — Load Context
 
@@ -32,6 +36,48 @@ If you haven't completed Phase 1 (Reproduce & Isolate), you cannot propose fixes
 3. **Identify the bug**:
    - If `$ARGUMENTS` provided: use as the bug description
    - If no arguments: ask the user to describe the bug, provide error output, or point to the failing test
+
+## Phase 0.5 — Root-Cause Prelude (MANDATORY before any Edit)
+
+Before touching a single file, post this block to the user and wait for confirmation
+OR explicitly pick a branch and name the disconfirming evidence. This exists because
+the #1 debugging failure mode is committing to hypothesis #1 and editing the wrong
+component (see the WhatsApp UserMenu/Banner and dual-SIM sagas in memory).
+
+### Required output — "Top-3 Candidates"
+
+```
+🔎 Root-Cause Prelude — [bug summary]
+
+Reproduction confirmed: [YES — <how> | NO — need <screenshot/logs/steps>]
+
+Top-3 candidate root causes (ranked by prior likelihood):
+
+1. [hypothesis] — <component/file:line>
+   Supporting: [observation + evidence level 1-6]
+   Disconfirming test: [one cheap check that would rule this OUT]
+
+2. [hypothesis] — <component/file:line>
+   Supporting: [observation + evidence level]
+   Disconfirming test: [cheap check]
+
+3. [hypothesis] — <component/file:line>
+   Supporting: [observation + evidence level]
+   Disconfirming test: [cheap check]
+
+Picked: #<N> because [disconfirming evidence for others is stronger than for this].
+```
+
+### Rules
+
+- **Do not skip this block** even for "obvious" bugs. Obvious bugs are where wrong-component detours happen.
+- **Do not collapse to 1 candidate** until disconfirming checks have been run on the other two. Listing one candidate = speculation.
+- **If reproduction is `NO`**: STOP and ask the user for a screenshot, log excerpt, or exact repro steps. Do not proceed to Phase 1.
+- **If the user redirects** ("look at X instead", "that's not the bug"): re-run this prelude with their new information. Do not continue with the old hypothesis.
+
+Only after the prelude passes do you delegate to Phase 1.
+
+---
 
 ## Phase 1 — Reproduce & Isolate
 

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -130,9 +130,9 @@ Then:
 
 ---
 
-## Step 4 — Parallel Code Review (4 agents)
+## Step 4 — Parallel Code Review (5 agents)
 
-Launch these four agents simultaneously using the Agent tool. Each agent should:
+Launch these five agents **in a single message with multiple Agent tool calls**, so they run concurrently. Sequential dispatch defeats the purpose. Each agent should:
 - Use `git diff --name-only <base-branch>...HEAD` (the detected base branch from Step 0) to scope review to changed files only
 - Check `git log --oneline -10` for recent commit context before recommending reversals
 - Focus on issues **introduced** by this session, not pre-existing patterns
@@ -180,6 +180,17 @@ Every finding MUST use exactly one of these severity tags:
 - Flag missing edge case tests, error path tests, boundary conditions
 - Check that existing tests still align with the changed behavior
 - Recommend specific tests to add (unit, integration, or e2e)
+
+### Agent 5: Adversarial Critic (`critic` subagent, model: sonnet)
+- Read the spec(s) touched this session and every AC
+- Ask "what AC is this missing?" and "what user-facing behavior would break?"
+- Specifically hunt for: response-shape mismatches between handler and consumer,
+  declared-done-without-e2e patterns, duplicate todo blocks, stale spec references
+- Check the API contract changes against any clients (frontend, tests, docs)
+- Report findings in the same severity format as Agents 1-4
+
+The critic is the guard against the "declared done before E2E" failure mode.
+It cares about gaps between spec and implementation, not style.
 
 ### Agent Failure Handling
 
@@ -335,7 +346,7 @@ Before committing, verify the code review from Step 4 completed with full covera
 
 | Review Status | Action |
 |---------------|--------|
-| **All 4 agents returned results AND all MUST-FIX applied AND ≤3 SHOULD-FIX skipped** | Proceed to commit & push |
+| **All 5 agents returned results AND all MUST-FIX applied AND ≤3 SHOULD-FIX skipped** | Proceed to commit & push |
 | **Any MUST-FIX finding was skipped** | **STOP** — present the skipped MUST-FIX finding(s) and ask the user: _"These MUST-FIX findings were not applied: [list]. Proceed anyway? (y/n)"_. Do not push without explicit user approval. |
 | **More than 3 SHOULD-FIX findings were skipped** | **STOP** — present all skipped SHOULD-FIX items with their justifications and ask the user: _"[N] SHOULD-FIX findings were skipped (max 3 allowed): [list]. Approve these skips? (y/n)"_. Do not push without explicit user approval. |
 | **Any agent failed** (status: `degraded`) | **STOP** — report which review dimensions were missed, show the manual spot-check findings, and ask the user: _"Code review was incomplete ([agent name] failed). Proceed with push anyway? (y/n)"_. Do not push without explicit user approval. |


### PR DESCRIPTION
Implements six improvements derived from last session's CC insights
analysis, targeting the three recurring failure modes: forgot-to-push,
single-hypothesis tunnel vision, and done-without-e2e.

Hooks (new/updated):
- pre-push-guard.sh: runs typecheck/lint before `git push`; blocks force
  push unless ALLOW_FORCE_PUSH=1; warns when "done"-style echoes run with
  unpushed commits
- session-stop.sh: removes active-session sentinel; warns on unpushed
  commits at session end
- cron-quiet-hours.sh: library for cron jobs to suppress noisy reporting
  during active sessions (failure-only path, per observability rule)
- session-start.sh: writes /tmp/claude-code-session-active sentinel for
  cron-quiet-hours consumers
- settings.json: wires PreToolUse(Bash) + Stop hooks

Skills:
- build: Phase 6 Build Report now requires an on-disk persistence proof
  block (paths, git state, push status) before claiming complete; E2E
  gate made non-skippable for user-facing ACs
- debug: new Phase 0.5 Root-Cause Prelude forces Top-3 candidate
  hypotheses with disconfirming tests before any Edit; Iron Law updated
- wrap-up-session: 5th review agent (critic) joins the parallel fan-out
  to hunt spec/implementation gaps and declared-done-without-e2e patterns

https://claude.ai/code/session_01QpRpHGLr5VhK2oAFsHAqYx