### PR TITLE
Cap context window and lock effort level via env overrides

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -42,5 +42,10 @@
         ]
       }
     ]
+  },
+  "env": {
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000",
+    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+    "CLAUDE_CODE_EFFORT_LEVEL": "high"
   }
 }


### PR DESCRIPTION
## Summary
- Add `env` block to `.claude/settings.json` mirroring the user-level settings:
  - `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000` — cap effective context at 400k tokens
  - `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1` — don't let Claude Code silently downshift reasoning
  - `CLAUDE_CODE_EFFORT_LEVEL=high` — pin effort level

## Test plan
- [ ] Start a new session in this repo, confirm env vars are applied

https://claude.ai/code/session_01Cv398aWJEp4yBEJw8wWbMr