### PR TITLE
feat: Surgical Changes rules + Ambiguity Protocol (from Karpathy-skills analysis)

### DIFF
--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -150,6 +150,34 @@ If ANY AC is classified `user-facing`, invoke `/verify --scope e2e` before decla
    - **Different failures** → record in `previous_failures`, add tasks, loop to Phase 1
 6. **After round 3 with remaining `❌`**: HALT with full status report, escalate to user
 
+## Phase 4.5 — Ambiguity Batch Review
+
+Per `.claude/project.md` § *Ambiguity Protocol*, sub-agents emit a single line
+when they hit a question whose answer changes the implementation:
+
+```
+[AMBIGUITY] <description> | options: A) ... B) ... | picked: <letter> | reason: ...
+```
+
+After Phase 4 passes:
+
+1. **Grep every agent output captured this build** for lines starting with `[AMBIGUITY]`.
+2. If zero hits: skip this phase silently.
+3. If one or more hits: surface them to the user as a single batch in this format:
+
+   ```
+   ⚠ Ambiguities resolved during build (please confirm):
+
+   1. <description>
+      Picked: <letter> (<reason>)
+      Alternatives: <other options>
+      Touched: <file paths>
+   2. ...
+   ```
+
+4. **Do not block** on user response — proceed to Phase 5. The batch is informational;
+   the user can request changes in a follow-up turn if a pick was wrong.
+
 ## Phase 5 — Backlog Update
 
 If `tasks/backlog.md` exists:

--- a/.claude/agents/backend-developer.md
+++ b/.claude/agents/backend-developer.md
@@ -45,3 +45,20 @@ You are a backend development expert specializing in building high-performance, 
 - Monitoring dashboards and alerting rules
 
 Build systems that can handle production load while maintaining code quality and security standards. Always consider scalability and maintainability in architectural decisions.
+
+## Surgical Changes & Ambiguity
+
+When modifying existing code, follow `.claude/project.md` § *Surgical Changes*:
+- Every changed line must trace to the current task. No drive-by refactors.
+- Match the surrounding file's existing style even if you would write it differently.
+- Remove only orphans *your* changes created; mention but don't delete pre-existing dead code.
+
+When you hit a question whose answer changes the implementation, do **not** silently pick.
+Pick one, proceed, and emit a single line in this exact format so the orchestrator can surface it:
+
+```
+[AMBIGUITY] <one-sentence description> | options: A) <option> B) <option> | picked: <letter> | reason: <one sentence>
+```
+
+Use only for genuine semantic ambiguity (e.g. "export all users vs. only active?", "throw vs. Result?").
+Do not use for stylistic choices or questions a quick file read would answer.

--- a/.claude/agents/frontend-developer.md
+++ b/.claude/agents/frontend-developer.md
@@ -42,3 +42,20 @@ You are a frontend development specialist focused on creating exceptional user e
 - Cross-browser compatibility testing results
 
 Focus on shipping production-ready code with excellent user experience. Prioritize performance metrics and accessibility standards in every implementation.
+
+## Surgical Changes & Ambiguity
+
+When modifying existing code, follow `.claude/project.md` § *Surgical Changes*:
+- Every changed line must trace to the current task. No drive-by refactors.
+- Match the surrounding file's existing style (naming, CSS conventions, component patterns) even if you would write it differently.
+- Remove only orphans *your* changes created; mention but don't delete pre-existing dead code.
+
+When you hit a question whose answer changes the implementation, do **not** silently pick.
+Pick one, proceed, and emit a single line in this exact format so the orchestrator can surface it:
+
+```
+[AMBIGUITY] <one-sentence description> | options: A) <option> B) <option> | picked: <letter> | reason: <one sentence>
+```
+
+Use only for genuine semantic ambiguity (e.g. "modal vs. inline error?", "optimistic update vs. wait for server?").
+Do not use for stylistic choices or questions a quick file read would answer.

--- a/.claude/project.md
+++ b/.claude/project.md
@@ -52,4 +52,47 @@ shown below — not active in this template):
 > Examples: tech-stack conventions, architectural constraints, domain glossary,
 > external service credentials policy.
 
-_None yet._
+### Surgical Changes
+
+Tightens `CLAUDE.md` § *Minimal Impact* with three operational tests. Apply to every
+code-modifying turn (main thread and sub-agents).
+
+1. **Trace test** — every changed line must trace directly to the current task or
+   user request. If you cannot point to the sentence in the spec / todo / user
+   message that motivates a hunk, revert it.
+2. **Style match** — match the surrounding file's existing style (naming,
+   formatting, error handling, comment density) even if you would write it
+   differently in a greenfield. Style drift is a separate PR.
+3. **Orphan rule** — remove only the imports, variables, and functions that
+   *your* changes made unused. Do not delete pre-existing dead code; if you
+   notice it, mention it in the turn summary and move on.
+
+These rules do **not** override explicit refactor or cleanup tasks. They apply
+when the task is a feature, fix, or targeted change.
+
+### Ambiguity Protocol
+
+When a sub-agent (or the main thread during `/build`) encounters **genuine
+semantic ambiguity** — not a stylistic choice, not a missing import, but a
+question whose answer changes the implementation — it must surface the
+question rather than silently picking.
+
+**Emission format** (single line, parseable by the orchestrator):
+
+```
+[AMBIGUITY] <one-sentence description> | options: A) <option> B) <option> [C) ...] | picked: <letter> | reason: <one sentence>
+```
+
+Rules:
+- The agent **picks one option and proceeds** (don't block on a question).
+- The orchestrator collects every `[AMBIGUITY]` line emitted during the run
+  and surfaces them as a single batch to the user at the end of `/build`,
+  before `/quality-gate` runs.
+- Use sparingly. Stylistic preferences, naming bikesheds, and questions
+  answered by reading one more file do **not** qualify. Examples that do:
+  - "Spec says 'export users' — entire table or only active users?"
+  - "Validation failure: throw vs. return `Result<Err>`? Codebase has both."
+  - "AC mentions retry — exponential backoff or fixed interval?"
+
+If unsure whether something qualifies, default to **not** emitting and noting
+the assumption in the turn summary instead.

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -278,6 +278,34 @@ Status marks distinguish evidence strength:
    Escalating to user.
    ```
 
+## Phase 4.5 — Ambiguity Batch Review
+
+Per `.claude/project.md` § *Ambiguity Protocol*, sub-agents emit a single line
+when they hit a question whose answer changes the implementation:
+
+```
+[AMBIGUITY] <description> | options: A) ... B) ... | picked: <letter> | reason: ...
+```
+
+After Phase 4 passes:
+
+1. **Grep every agent output captured this build** for lines starting with `[AMBIGUITY]`.
+2. If zero hits: skip this phase silently.
+3. If one or more hits: surface them to the user as a single batch in this format:
+
+   ```
+   ⚠ Ambiguities resolved during build (please confirm):
+
+   1. <description>
+      Picked: <letter> (<reason>)
+      Alternatives: <other options>
+      Touched: <file paths>
+   2. ...
+   ```
+
+4. **Do not block** on user response — proceed to Phase 5. The batch is informational;
+   the user can request changes in a follow-up turn if a pick was wrong.
+
 ## Phase 5 — Backlog Update
 
 If `tasks/backlog.md` exists:


### PR DESCRIPTION
## Summary

Two scoped additions surfaced by deep-analysis of [`multica-ai/andrej-karpathy-skills`](https://github.com/multica-ai/andrej-karpathy-skills). The analysis found three of four Karpathy principles already covered by our `/plan` → `/build` → `/quality-gate` pipeline at equal or greater rigor; this PR patches the two genuine gaps.

### 1. Surgical Changes — `.claude/project.md`
Tightens the existing `CLAUDE.md` *Minimal Impact* posture into three operational tests:
- **Trace test** — every changed line traces directly to the task; otherwise revert
- **Style match** — match the surrounding file's existing style even if you'd write it differently
- **Orphan rule** — remove only orphans *your* changes created; mention but don't delete pre-existing dead code

Sharper than the prior one-liner; gives sub-agents and reviewers concrete checks instead of a posture.

### 2. Ambiguity Protocol — `.claude/project.md` + `backend-developer` + `frontend-developer` + `/build` Phase 4.5
Defines a single-line emission format for sub-agents to surface genuine semantic ambiguity instead of silently picking:

```
[AMBIGUITY] <description> | options: A) ... B) ... | picked: <letter> | reason: ...
```

- Sub-agents pick one and proceed (does not block `/build` autonomy)
- New `/build` Phase 4.5 greps agent outputs, surfaces all emissions as a single non-blocking batch before backlog update
- Scoped strictly to genuine semantic ambiguity (not stylistic choices, not questions a file read would answer)

Mirrors the same edit to both `.claude/skills/build/SKILL.md` and `.agents/skills/build/SKILL.md` (canonical + back-compat copies).

## Files

- `.claude/project.md` — adds *Surgical Changes* and *Ambiguity Protocol* sections under *Project-Specific Rules*
- `.claude/agents/backend-developer.md` — adds *Surgical Changes & Ambiguity* section
- `.claude/agents/frontend-developer.md` — adds *Surgical Changes & Ambiguity* section
- `.claude/skills/build/SKILL.md` — adds *Phase 4.5 — Ambiguity Batch Review*
- `.agents/skills/build/SKILL.md` — adds *Phase 4.5 — Ambiguity Batch Review*

## What we explicitly did NOT take from Karpathy-skills

- Their single-skill / single-CLAUDE.md model — would lose our multi-skill orchestration
- Plugin-marketplace distribution — incompatible with our template + `/sync` model
- Wholesale principle wording — heavy overlap with existing rules would cause duplication and subtle clashes (e.g. their "match style" vs. our Clean Code naming rules)

Their *Simplicity First* and *Goal-Driven Execution* are already covered (or exceeded) by `/simplify`, `/deslop`, APOSD review, and the `/plan` → `/build` TDD pipeline — no edit needed there.

## Test plan

- [ ] Run `/build` on a small task that contains a real semantic ambiguity; confirm sub-agent emits `[AMBIGUITY]` line and orchestrator surfaces it in Phase 4.5
- [ ] Run `/build` on an unambiguous task; confirm Phase 4.5 is silent (no false positives)
- [ ] Have a sub-agent attempt a drive-by refactor in a feature task; confirm the trace-test rule causes it to revert or scope down
- [ ] Verify `.claude/project.md` is still imported correctly by `CLAUDE.md` after the additions

---
_Generated by [Claude Code](https://claude.ai/code/session_01AgNN1br4MsLJQvmLYeCHek)_