### PR TITLE
Add Code Economy rule (generation-time minimalism gate)

### DIFF
--- a/.claude/project.md
+++ b/.claude/project.md
@@ -52,6 +52,35 @@ shown below — not active in this template):
 > Examples: tech-stack conventions, architectural constraints, domain glossary,
 > external service credentials policy.
 
+### Code Economy
+
+A **generation-time** gate that runs *before* you write code — the preventive
+counterpart to the post-hoc `/simplify`, `/deslop`, and `/quality-gate` passes.
+Apply to every code-writing turn (main thread and sub-agents). The cheapest line
+to review is the one never written.
+
+**Decision hierarchy** — walk top to bottom; stop at the first that applies:
+
+1. **Necessity (YAGNI)** — does this need to exist at all? Skip speculative
+   abstractions, config knobs with one setting, and features no AC asks for.
+2. **Standard library** — does the language's stdlib already provide it? Prefer
+   it over a hand-rolled equivalent.
+3. **Native platform** — does the OS/browser/runtime provide it? (e.g.
+   `<input type="date">` over a date-picker dependency.)
+4. **Existing dependency** — is it already installed? Reuse it before adding a
+   new one. **Do not add a dependency for what 1–3 already cover.**
+5. **One line** — if a correct one-liner exists, write the one-liner.
+6. **Minimal viable code** — only then write the least code that satisfies the AC.
+
+**Never-on-the-chopping-block** (these override the hierarchy — economy never
+justifies cutting them; see `CLAUDE.md` § *No Silent Failures* and `/security-scan`):
+security, accessibility, trust-boundary input validation, error handling that
+prevents data loss, and anything the user explicitly requested.
+
+**Intentional shortcuts** — when you deliberately pick a minimal solution with a
+known limitation, mark it with a `TODO(shortcut):` comment stating the limit and
+the upgrade path. `/deslop` preserves `TODO/FIXME`, so the marker survives cleanup.
+
 ### Surgical Changes
 
 Tightens `CLAUDE.md` § *Minimal Impact* with three operational tests. Apply to every

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,4 +11,30 @@
 > Add project-specific rules for Pi here.
 > Examples: tech-stack conventions, architectural constraints, domain glossary, service URLs.
 
-_None yet._
+### Code Economy
+
+A **generation-time** gate that runs *before* you write code — the preventive
+counterpart to the post-hoc `/simplify`, `/deslop`, and `/quality-gate` passes.
+Apply to every code-writing turn. The cheapest line to review is the one never written.
+
+**Decision hierarchy** — walk top to bottom; stop at the first that applies:
+
+1. **Necessity (YAGNI)** — does this need to exist at all? Skip speculative
+   abstractions, config knobs with one setting, and features no AC asks for.
+2. **Standard library** — does the language's stdlib already provide it? Prefer
+   it over a hand-rolled equivalent.
+3. **Native platform** — does the OS/browser/runtime provide it? (e.g.
+   `<input type="date">` over a date-picker dependency.)
+4. **Existing dependency** — is it already installed? Reuse it before adding a
+   new one. **Do not add a dependency for what 1–3 already cover.**
+5. **One line** — if a correct one-liner exists, write the one-liner.
+6. **Minimal viable code** — only then write the least code that satisfies the AC.
+
+**Never-on-the-chopping-block** (these override the hierarchy — economy never
+justifies cutting them; see `CLAUDE.md` § *No Silent Failures*): security,
+accessibility, trust-boundary input validation, error handling that prevents
+data loss, and anything the user explicitly requested.
+
+**Intentional shortcuts** — when you deliberately pick a minimal solution with a
+known limitation, mark it with a `TODO(shortcut):` comment stating the limit and
+the upgrade path.


### PR DESCRIPTION
## Summary

Ports the one genuinely net-new idea from the [Ponytail](https://github.com/DietrichGebert/ponytail) skill — a **generation-time minimalism gate** — into our two always-on rule surfaces (`.claude/project.md` for Claude Code, `AGENTS.md` for Pi).

This came out of a scope analysis comparing Ponytail against our existing workflow. The finding: ~80% of Ponytail's scope is already covered (usually more rigorously) by `/simplify`, `/deslop`, `/quality-gate`, and our TDD/APOSD/security gates. The gaps were structural, not feature-level.

## What this adds

A **Code Economy** section with a decision hierarchy walked before writing code:

1. **Necessity (YAGNI)** — does it need to exist at all?
2. **Standard library** — does stdlib already provide it?
3. **Native platform** — does the OS/browser/runtime provide it?
4. **Existing dependency** — reuse before adding a new one
5. **One line** — write the one-liner if one is correct
6. **Minimal viable code** — least code that satisfies the AC

The **stdlib → native platform → existing-dependency ladder** (steps 2–4) is the only part of Ponytail's scope not already covered by an existing skill. The rest converts our *reactive* cleanup passes into a *preventive* posture — slop prevented at write time rather than deleted afterward.

## Guardrails

- **Carve-outs** (security, accessibility, trust-boundary validation, data-loss handling, explicit user asks) are wired to the existing `CLAUDE.md` § *No Silent Failures* rule and `/security-scan`, so economy can never justify cutting them.
- **Intentional shortcuts** use a `TODO(shortcut):` marker — folded into the `TODO/FIXME` convention `/deslop` already preserves, rather than inventing a new token.

## Deliberately not brought over

The full Ponytail skill, its three `/ponytail-*` commands (covered by `/simplify` + `/quality-gate`), the benchmark assets, and the 5 editor-specific rule files — all either duplicative or below our quality bar.

## Files

- `.claude/project.md` — new `### Code Economy` section, placed before *Surgical Changes*
- `AGENTS.md` — same content, replacing the empty placeholder

https://claude.ai/code/session_019HXRrY92M17Hxj1jP9vz7w

---
_Generated by [Claude Code](https://claude.ai/code/session_019HXRrY92M17Hxj1jP9vz7w)_