### PR TITLE
refactor(auto-improve): triage-first hybrid discovery (follow-up to #39)

### DIFF
--- a/.agents/skills/auto-improve/SKILL.md
+++ b/.agents/skills/auto-improve/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: auto-improve
-description: Autonomous discover-then-fix loop. Surveys backlog, technical debt, test results, performance, and design, ranks the highest-value improvement, implements exactly one with TDD, and opens a PR. Built for daily unattended cloud runs.
+description: Autonomous discover-then-fix loop. Triages the existing backlog/bugs first and acts on a ready item when one exists; runs a full parallel discovery scan only when the backlog is dry or on the weekly deep-sweep day. Implements exactly one improvement with TDD and opens a PR. Built for daily unattended cloud runs.
 argument-hint: "[optional focus area, e.g. 'router' or 'perf']"
 harness: universal
 ---
 
-# /auto-improve — Discover the Work, Ship One Improvement
+# /auto-improve — Triage First, Discover When Dry, Ship One Improvement
 
-An unattended cousin of `/auto-push`. Nobody hands you a plan. You **survey the codebase's health**, pick the single highest-value improvement, implement it with TDD, verify no regressions, and open a PR — all in one run, no user prompts.
+An unattended cousin of `/auto-push`. Nobody hands you a plan. You **act on already-flagged work first**, fall back to **fresh discovery only when there's nothing ready to act on** (or on the weekly deep-sweep day), then implement the single highest-value improvement with TDD, verify no regressions, and open a PR — all in one run, no user prompts.
 
-Designed to run daily on the cloud. It must be conservative: one focused, reviewable change per run beats a sprawling risky diff.
+Designed to run daily on the cloud. Be conservative: one focused, reviewable change per run beats a sprawling risky diff, and cheap days (act on backlog) should not pay for a full deep scan.
 
 ---
 
@@ -19,6 +19,7 @@ Designed to run daily on the cloud. It must be conservative: one focused, review
 ONE RUN → ONE PR → EXACTLY ONE IMPROVEMENT.
 NEVER PUSH TO main/master. PR ONLY.
 NO PR IF THE FULL TEST SUITE IS NOT GREEN.
+TRIAGE BEFORE YOU DISCOVER — do not run the deep scan when a ready backlog item exists (unless it is the weekly deep-sweep day).
 IF NO SAFE IMPROVEMENT EXISTS, LOG FINDINGS TO backlog.md AND OPEN A DOCS-ONLY PR — DO NOT FORCE A CHANGE.
 ```
 
@@ -30,14 +31,26 @@ The moment you are tempted to bundle a second unrelated fix "while you're here" 
 
 1. **Read the working memory**: `tasks/memory.md`, `tasks/lessons.md`, `tasks/todo.md`, `tasks/bugs.md`, `tasks/backlog.md`. Skip any that don't exist.
 2. **Branch safety**: `git rev-parse --abbrev-ref HEAD`. Create a fresh working branch `claude/auto-improve-<date>`; never work on `main`/`master`/`develop`.
-3. **Clean tree**: `git status --short`. If unrelated uncommitted changes exist, stash-or-surface but do not silently include them in the PR.
+3. **Clean tree**: `git status --short`. If unrelated uncommitted changes exist, surface but do not silently include them in the PR.
 4. **Green baseline**: run the full test suite (see `tasks/memory.md` for the exact runner — this project uses `/home/joaosouto/venv/bin/pytest tests/`). If the baseline is RED, that failing test *becomes* the improvement to fix. Do not build on top of a broken baseline.
 
 If a guard cannot be satisfied and it is not itself the thing to fix, STOP and report — do not proceed.
 
 ---
 
-## Phase 1 — DISCOVER (parallel survey)
+## Phase 1 — TRIAGE (cheap, always) → discovery gate
+
+First, spend almost nothing deciding whether you even need to discover.
+
+1. **Scan already-flagged work** (read-only, no subagents): from `tasks/backlog.md`, `tasks/bugs.md`, and `tasks/todo.md`, collect every item that is **ready-to-act** — meaning it is triaged, has enough context to implement cold, is unblocked, and is not marked done/wontfix.
+2. **Determine the deep-sweep day**: check today's date. If it is **Sunday** (the weekly deep-sweep day), you will run full discovery regardless, so debt/design/perf still gets found on a regular cadence.
+3. **Gate**:
+   - **Ready item exists AND it is not the deep-sweep day** → **skip discovery entirely.** Go to Phase 2 and select among the ready backlog/bug items. This is the cheap common path.
+   - **No ready item exists, OR it is the deep-sweep day** → run **DISCOVERY** below, then Phase 2.
+
+State in your output which branch of the gate you took and why (e.g. "3 ready backlog items; not Sunday → skipping deep scan").
+
+### DISCOVERY (only when the gate opens)
 
 Dispatch independent read-only sub-agents **in parallel** (one message, multiple Agent calls) to build a candidate list. Each returns findings with `{title, category, file:line, severity, est. effort, risk}`:
 
@@ -46,21 +59,20 @@ Dispatch independent read-only sub-agents **in parallel** (one message, multiple
 | Test health | sonnet | Run full suite + coverage. Report failing tests, flaky tests, coverage gaps < 80%, slowest tests. |
 | Design review | sonnet | Run `/software-design-expert-review` on recently changed + core files. Report MUST-FIX / SHOULD-FIX APOSD red flags. |
 | Performance | sonnet | Scan hot paths (pipeline stages, router, encoders) for obvious inefficiencies — redundant work, N+1 subprocess calls, unbounded loops. |
-| Backlog & bugs | haiku | Read `backlog.md` + `bugs.md`. Surface the highest-priority already-triaged items with enough context to act. |
 
-Do **not** fix anything in this phase. Discovery is read-only.
+Do **not** fix anything in this phase. Discovery is read-only. Merge these findings with the ready backlog/bug items for ranking in Phase 2.
 
 ---
 
 ## Phase 2 — SELECT (rank, pick one)
 
-Merge all findings into a single ranked table scored on **value ÷ (effort × risk)**:
+Rank the candidate pool — either the ready backlog items alone (cheap path) or backlog + freshly-discovered findings (discovery path) — scored on **value ÷ (effort × risk)**:
 
 - **Value**: user-facing bug > flaky test > perf win > design/maintainability > cosmetic.
 - **Effort**: prefer changes shippable within one run as a small, reviewable diff.
 - **Risk**: prefer changes with existing test coverage or an easy new test. Deprioritize anything touching public interfaces or lacking a safety net.
 
-Pick **exactly one** item (respect `$ARGUMENTS` as a focus filter if given). Write the ranked list to `tasks/backlog.md` so unpicked candidates persist for future runs. State the pick and the one-line rationale in your output.
+Pick **exactly one** item (respect `$ARGUMENTS` as a focus filter if given). If discovery ran, write the newly-found unpicked candidates to `tasks/backlog.md` so they persist for future runs. State the pick and the one-line rationale in your output.
 
 If the top candidate's risk is high and coverage is thin → drop to the next safe one. If **nothing** is safely actionable → skip to Phase 5 in "findings-only" mode.
 

--- a/.claude/skills/auto-improve/SKILL.md
+++ b/.claude/skills/auto-improve/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: auto-improve
-description: Autonomous discover-then-fix loop. Surveys backlog, technical debt, test results, performance, and design, ranks the highest-value improvement, implements exactly one with TDD, and opens a PR. Built for daily unattended cloud runs.
+description: Autonomous discover-then-fix loop. Triages the existing backlog/bugs first and acts on a ready item when one exists; runs a full parallel discovery scan only when the backlog is dry or on the weekly deep-sweep day. Implements exactly one improvement with TDD and opens a PR. Built for daily unattended cloud runs.
 argument-hint: "[optional focus area, e.g. 'router' or 'perf']"
 harness: universal
 ---
 
-# /auto-improve — Discover the Work, Ship One Improvement
+# /auto-improve — Triage First, Discover When Dry, Ship One Improvement
 
-An unattended cousin of `/auto-push`. Nobody hands you a plan. You **survey the codebase's health**, pick the single highest-value improvement, implement it with TDD, verify no regressions, and open a PR — all in one run, no user prompts.
+An unattended cousin of `/auto-push`. Nobody hands you a plan. You **act on already-flagged work first**, fall back to **fresh discovery only when there's nothing ready to act on** (or on the weekly deep-sweep day), then implement the single highest-value improvement with TDD, verify no regressions, and open a PR — all in one run, no user prompts.
 
-Designed to run daily on the cloud. It must be conservative: one focused, reviewable change per run beats a sprawling risky diff.
+Designed to run daily on the cloud. Be conservative: one focused, reviewable change per run beats a sprawling risky diff, and cheap days (act on backlog) should not pay for a full deep scan.
 
 ---
 
@@ -19,6 +19,7 @@ Designed to run daily on the cloud. It must be conservative: one focused, review
 ONE RUN → ONE PR → EXACTLY ONE IMPROVEMENT.
 NEVER PUSH TO main/master. PR ONLY.
 NO PR IF THE FULL TEST SUITE IS NOT GREEN.
+TRIAGE BEFORE YOU DISCOVER — do not run the deep scan when a ready backlog item exists (unless it is the weekly deep-sweep day).
 IF NO SAFE IMPROVEMENT EXISTS, LOG FINDINGS TO backlog.md AND OPEN A DOCS-ONLY PR — DO NOT FORCE A CHANGE.
 ```
 
@@ -30,14 +31,26 @@ The moment you are tempted to bundle a second unrelated fix "while you're here" 
 
 1. **Read the working memory**: `tasks/memory.md`, `tasks/lessons.md`, `tasks/todo.md`, `tasks/bugs.md`, `tasks/backlog.md`. Skip any that don't exist.
 2. **Branch safety**: `git rev-parse --abbrev-ref HEAD`. Create a fresh working branch `claude/auto-improve-<date>`; never work on `main`/`master`/`develop`.
-3. **Clean tree**: `git status --short`. If unrelated uncommitted changes exist, stash-or-surface but do not silently include them in the PR.
+3. **Clean tree**: `git status --short`. If unrelated uncommitted changes exist, surface but do not silently include them in the PR.
 4. **Green baseline**: run the full test suite (see `tasks/memory.md` for the exact runner — this project uses `/home/joaosouto/venv/bin/pytest tests/`). If the baseline is RED, that failing test *becomes* the improvement to fix. Do not build on top of a broken baseline.
 
 If a guard cannot be satisfied and it is not itself the thing to fix, STOP and report — do not proceed.
 
 ---
 
-## Phase 1 — DISCOVER (parallel survey)
+## Phase 1 — TRIAGE (cheap, always) → discovery gate
+
+First, spend almost nothing deciding whether you even need to discover.
+
+1. **Scan already-flagged work** (read-only, no subagents): from `tasks/backlog.md`, `tasks/bugs.md`, and `tasks/todo.md`, collect every item that is **ready-to-act** — meaning it is triaged, has enough context to implement cold, is unblocked, and is not marked done/wontfix.
+2. **Determine the deep-sweep day**: check today's date. If it is **Sunday** (the weekly deep-sweep day), you will run full discovery regardless, so debt/design/perf still gets found on a regular cadence.
+3. **Gate**:
+   - **Ready item exists AND it is not the deep-sweep day** → **skip discovery entirely.** Go to Phase 2 and select among the ready backlog/bug items. This is the cheap common path.
+   - **No ready item exists, OR it is the deep-sweep day** → run **DISCOVERY** below, then Phase 2.
+
+State in your output which branch of the gate you took and why (e.g. "3 ready backlog items; not Sunday → skipping deep scan").
+
+### DISCOVERY (only when the gate opens)
 
 Dispatch independent read-only sub-agents **in parallel** (one message, multiple Agent calls) to build a candidate list. Each returns findings with `{title, category, file:line, severity, est. effort, risk}`:
 
@@ -46,21 +59,20 @@ Dispatch independent read-only sub-agents **in parallel** (one message, multiple
 | Test health | sonnet | Run full suite + coverage. Report failing tests, flaky tests, coverage gaps < 80%, slowest tests. |
 | Design review | sonnet | Run `/software-design-expert-review` on recently changed + core files. Report MUST-FIX / SHOULD-FIX APOSD red flags. |
 | Performance | sonnet | Scan hot paths (pipeline stages, router, encoders) for obvious inefficiencies — redundant work, N+1 subprocess calls, unbounded loops. |
-| Backlog & bugs | haiku | Read `backlog.md` + `bugs.md`. Surface the highest-priority already-triaged items with enough context to act. |
 
-Do **not** fix anything in this phase. Discovery is read-only.
+Do **not** fix anything in this phase. Discovery is read-only. Merge these findings with the ready backlog/bug items for ranking in Phase 2.
 
 ---
 
 ## Phase 2 — SELECT (rank, pick one)
 
-Merge all findings into a single ranked table scored on **value ÷ (effort × risk)**:
+Rank the candidate pool — either the ready backlog items alone (cheap path) or backlog + freshly-discovered findings (discovery path) — scored on **value ÷ (effort × risk)**:
 
 - **Value**: user-facing bug > flaky test > perf win > design/maintainability > cosmetic.
 - **Effort**: prefer changes shippable within one run as a small, reviewable diff.
 - **Risk**: prefer changes with existing test coverage or an easy new test. Deprioritize anything touching public interfaces or lacking a safety net.
 
-Pick **exactly one** item (respect `$ARGUMENTS` as a focus filter if given). Write the ranked list to `tasks/backlog.md` so unpicked candidates persist for future runs. State the pick and the one-line rationale in your output.
+Pick **exactly one** item (respect `$ARGUMENTS` as a focus filter if given). If discovery ran, write the newly-found unpicked candidates to `tasks/backlog.md` so they persist for future runs. State the pick and the one-line rationale in your output.
 
 If the top candidate's risk is high and coverage is thin → drop to the next safe one. If **nothing** is safely actionable → skip to Phase 5 in "findings-only" mode.
 


### PR DESCRIPTION
## What

Follow-up to #39. Changes `/auto-improve` from **always deep-scan** to a **triage-first hybrid**:

- **Cheap path (most days):** read backlog/bugs/todo; if a ready-to-act item exists and it isn't Sunday, act on it and **skip the deep scan** entirely.
- **Discovery path:** run the full parallel scan (test health + APOSD design + performance) only when the backlog is dry **or** on the weekly **Sunday deep-sweep** day, so debt/design still gets found on a cadence.

Everything else (TDD implement → verify → PR, one-improvement iron law, findings-only fallback) is unchanged.

## Why this is a separate PR

The hybrid commit was pushed to the #39 branch *after* #39 had already been merged, so it never made it to master. This re-lands it cleanly off current master.

## Files
- `.agents/skills/auto-improve/SKILL.md` (canonical)
- `.claude/skills/auto-improve/SKILL.md` (mirror)

Only the skill body/frontmatter changes; the `CLAUDE.md` + `session-start.sh` registrations from #39 already cover it.