### PR TITLE
feat(rules): add reuse rung + three guards to Code Economy

### DIFF
--- a/.claude/project.md
+++ b/.claude/project.md
@@ -63,14 +63,32 @@ to review is the one never written.
 
 1. **Necessity (YAGNI)** — does this need to exist at all? Skip speculative
    abstractions, config knobs with one setting, and features no AC asks for.
-2. **Standard library** — does the language's stdlib already provide it? Prefer
+2. **Existing code** — does a helper, util, type, or pattern already in this repo
+   do it? Reuse it. Re-implementing what lives a few files over is the most common
+   source of slop; `/quality-gate` Phase 1.1 catches it after the fact, this rung
+   prevents it.
+3. **Standard library** — does the language's stdlib already provide it? Prefer
    it over a hand-rolled equivalent.
-3. **Native platform** — does the OS/browser/runtime provide it? (e.g.
+4. **Native platform** — does the OS/browser/runtime provide it? (e.g.
    `<input type="date">` over a date-picker dependency.)
-4. **Existing dependency** — is it already installed? Reuse it before adding a
-   new one. **Do not add a dependency for what 1–3 already cover.**
-5. **One line** — if a correct one-liner exists, write the one-liner.
-6. **Minimal viable code** — only then write the least code that satisfies the AC.
+5. **Existing dependency** — is it already installed? Reuse it before adding a
+   new one. **Do not add a dependency for what 1–4 already cover.**
+6. **One line** — if a correct one-liner exists, write the one-liner.
+7. **Minimal viable code** — only then write the least code that satisfies the AC.
+
+**Understand first, then walk the hierarchy** — it shortens the solution, never
+the reading. Trace the real flow through every file the change touches before
+picking a level. The smallest change in the wrong place is not economy, it is a
+second bug.
+
+**Root cause over symptom** — a bug report names a symptom. Before editing, check
+every caller of the function you are about to touch: one guard in the shared
+function is a smaller diff than one guard per caller, and patching only the path
+the ticket names leaves sibling callers broken. The economical fix *is* the
+root-cause fix.
+
+**Tiebreak on correctness** — when two options cost the same number of lines, take
+the one that handles edge cases. Economy means less code, not a flimsier algorithm.
 
 **Never-on-the-chopping-block** (these override the hierarchy — economy never
 justifies cutting them; see `CLAUDE.md` § *No Silent Failures* and `/security-scan`):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,14 +21,28 @@ Apply to every code-writing turn. The cheapest line to review is the one never w
 
 1. **Necessity (YAGNI)** — does this need to exist at all? Skip speculative
    abstractions, config knobs with one setting, and features no AC asks for.
-2. **Standard library** — does the language's stdlib already provide it? Prefer
+2. **Existing code** — does a helper, util, type, or pattern already in this repo
+   do it? Reuse it. Re-implementing what lives a few files over is the most common
+   source of slop.
+3. **Standard library** — does the language's stdlib already provide it? Prefer
    it over a hand-rolled equivalent.
-3. **Native platform** — does the OS/browser/runtime provide it? (e.g.
+4. **Native platform** — does the OS/browser/runtime provide it? (e.g.
    `<input type="date">` over a date-picker dependency.)
-4. **Existing dependency** — is it already installed? Reuse it before adding a
-   new one. **Do not add a dependency for what 1–3 already cover.**
-5. **One line** — if a correct one-liner exists, write the one-liner.
-6. **Minimal viable code** — only then write the least code that satisfies the AC.
+5. **Existing dependency** — is it already installed? Reuse it before adding a
+   new one. **Do not add a dependency for what 1–4 already cover.**
+6. **One line** — if a correct one-liner exists, write the one-liner.
+7. **Minimal viable code** — only then write the least code that satisfies the AC.
+
+**Understand first, then walk the hierarchy** — it shortens the solution, never
+the reading. Trace the real flow through every file the change touches before
+picking a level. The smallest change in the wrong place is a second bug.
+
+**Root cause over symptom** — check every caller of the function you touch. One
+guard in the shared function is a smaller diff than one per caller, and patching
+only the path the ticket names leaves sibling callers broken.
+
+**Tiebreak on correctness** — two options, same line count? Take the one that
+handles edge cases. Economy means less code, not a flimsier algorithm.
 
 **Never-on-the-chopping-block** (these override the hierarchy — economy never
 justifies cutting them; see `CLAUDE.md` § *No Silent Failures*): security,


### PR DESCRIPTION
Second harvest from [Ponytail](https://github.com/DietrichGebert/ponytail). The first was ff2c1cc on the day it launched; this re-reviews the upstream ruleset after 7 weeks of upstream changes. **Four text deltas were worth porting. The plugin was not.**

Touches only the two always-on rule surfaces — `.claude/project.md` (Claude Code) and `AGENTS.md` (Pi). No code, no skills, no hooks.

## What changed

**New rung 2 — "Existing code"** (ladder 6 rungs → 7)

The old hierarchy jumped YAGNI → stdlib. So the most common form of slop — re-implementing a helper that already sits a few files over — had **no generation-time rung**. `/quality-gate` Phase 1.1 "Code Reuse" only caught it post-hoc, after the code was already written and reviewed. Upstream pins this rung as a test invariant (their #281), which matches where slop actually comes from in practice.

**Three guards** against failure modes the economy gate itself creates:

| Guard | Failure mode it closes |
|---|---|
| Understand first, then walk the hierarchy | Minimalism producing a confident, small, *wrong* diff. The hierarchy shortens the solution, never the reading. |
| Root cause over symptom | "Shortest diff" pushing toward patching the one caller the ticket names, leaving siblings broken. Reframes the root-cause fix as *also* the smaller one, rather than a competing goal. |
| Tiebreak on correctness | Equal-line-count options resolved toward the flimsier algorithm. |

The third is the smallest and the one I'd most expect pushback on — arguably rung 6 already implies it by saying "a *correct* one-liner." I kept it because it disambiguates the equal-cost case explicitly.

## Review notes

- **Both copies must stay in sync.** `grep` confirms no other file carries Code Economy (`project-template/CLAUDE.md` does not). The `project.md` copy cross-references `/quality-gate` Phase 1.1; the `AGENTS.md` copy is deliberately terser to match that file's existing register. That asymmetry is intentional and pre-existing, not drift.
- **Both files are `/sync`-safe** per their own headers, so this survives template pulls.
- **Carve-outs untouched.** § Never-on-the-chopping-block still overrides the whole hierarchy.

## Why not the plugin

Recorded here so the next person doesn't re-litigate it:

- **`SubagentStart` injects a lazy-dev persona into every subagent, fail-open.** Scoping needs a `PONYTAIL_SUBAGENT_MATCHER` regex; any parse error, stdin error, or 1s timeout still injects. That persona would contend with `security-reviewer`, `critic`, and `software-design-expert-review` — APOSD favours *deeper* modules, which sometimes means more implementation code behind a simpler interface.
- **Rule duplication.** Its `SessionStart` matcher includes `compact`, so the full ruleset re-injects after every compaction, stacking with `pre-compact.sh`. Two ladders with different numbering and a different shortcut marker (`ponytail:` vs our `TODO(shortcut):`, which `/deslop` is tuned to preserve).
- **`/sync` collision.** Its primary install path is an `AGENTS.md` at project root — a template-managed file here.
- **Benchmarks are thin.** "~54% less code" is n=4, one model (Haiku 4.5), one date, one fixture repo. The tasks driving the number are scored by "does a new file exist" — a stub scores the same as a working component. The repo ships a completeness judge (`complete.py`) whose own docstring calls this gap the most credible attack on the number; it wasn't run for the published result. Raw per-cell data is gitignored. Credit where due: they publicly retracted an earlier inflated figure and disclosed a baseline-contamination bug, which is above average for the genre.
- **Self-defeating.** Installing a Node hook system, MCP server, and mode state machine to deliver a ruleset our own always-on files already deliver would fail rungs 2–5 of the hierarchy it's asking us to follow.

## Testing

`bash tests/run.sh` → `RESULT: 2/9 test files FAILED`.

**Both failures are pre-existing and unrelated** — verified by stashing this change and re-running on a clean tree, which produces identical failures:

- `tests/test-session-start.sh` — 2/4 (compact restore block, skills banner); likely 86a1dbc
- `tests/test-skill-parity.sh` — `sync/SKILL.md` not byte-identical across trees; likely 2b671d1

Tracked separately, not fixed here.

## Not in scope

`TODO(shortcut):` is still write-only — nothing in the repo reads it back, so deliberate shortcuts have no ledger and can rot into "later means never." That's a code change; separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
