### PR TITLE
fix: sync-skill parity, unreachable compact branch, shortcut ledger

### DIFF
--- a/.agents/skills/wrap-up-session/SKILL.md
+++ b/.agents/skills/wrap-up-session/SKILL.md
@@ -94,6 +94,28 @@ Address any MUST-FIX findings before proceeding to commit.
 
 ---
 
+## Step 3.7 — Shortcut Ledger
+
+`CLAUDE.md` § *Code Economy* marks deliberate shortcuts with `TODO(shortcut):`
+naming a limit and an upgrade path. Collect them so a deferral cannot quietly
+become permanent:
+
+```bash
+grep -rnE '(#|//|--) ?TODO\(shortcut\):' . \
+  --exclude-dir={.git,node_modules,dist,build,vendor} 2>/dev/null || true
+```
+
+One line per marker: `<file>:<line> — <limit>. upgrade: <trigger>.` Tag any
+marker naming no upgrade path `no-trigger` — those are the ones that rot. Close
+with `<N> shortcuts, <M> without a trigger.`
+
+No markers found: print nothing and move on (failure-only reporting, per
+`CLAUDE.md` § *Observability Discipline*). This step reports only — it never
+blocks the commit, and shortcuts are not bugs, so they do not go in
+`tasks/bugs.md`.
+
+---
+
 ## Step 4 — Code Review (4 passes)
 
 Run 4 sequential self-review passes in the main context. For each pass:

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -20,12 +20,17 @@ DIVIDER="═══════════════════════�
 # ── Compaction-aware restore ─────────────────────────────────────────────────
 # Claude Code passes a `source` field (startup|resume|compact|clear) as JSON on
 # stdin. After a compaction we skip the heavy first-run banner and instead point
-# the agent at the state flushed to disk by the PreCompact hook. Older CLIs (or
-# missing jq) leave source=startup, preserving the full banner — no regression.
+# the agent at the state flushed to disk by the PreCompact hook. Parsed with sed
+# rather than jq: re-orientation matters most at exactly this moment, so the
+# branch must not vanish on a machine that lacks an optional binary. Older CLIs
+# omit the field — source stays startup, preserving the full banner, no
+# regression. The tty guard keeps a manual run from blocking on empty stdin.
 HOOK_SOURCE="startup"
-if command -v jq >/dev/null 2>&1; then
+if [ ! -t 0 ]; then
   HOOK_INPUT=$(cat 2>/dev/null || true)
-  HOOK_SOURCE=$(printf '%s' "$HOOK_INPUT" | jq -r '.source // "startup"' 2>/dev/null || echo startup)
+  HOOK_SOURCE=$(printf '%s' "$HOOK_INPUT" \
+    | sed -n 's/.*"source"[[:space:]]*:[[:space:]]*"\([A-Za-z]*\)".*/\1/p' | head -1 || true)
+  HOOK_SOURCE="${HOOK_SOURCE:-startup}"
 fi
 
 # ── Double-invocation guard ──────────────────────────────────────────────────

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -53,6 +53,14 @@ one-line `🔄 TEMPLATE DRIFT` notice at session start when syncable paths diffe
 from `workflow/<default-branch>`. It does **not** modify files — it only nudges
 you to run `/sync`.
 
+**Where the hook is registered:** `install.sh` registers `SessionStart` at the **user**
+level only (`~/.claude/hooks/session-start.sh` + `~/.claude/settings.json`) — once per
+machine, covering every project. It is deliberately **not** registered in the
+project-level `.claude/settings.json` that `/sync` copies. Registering it in both places
+makes the hook fire twice per session and print the banner twice. Do not "helpfully" add
+a `SessionStart` entry to `.claude/settings.json` — syncing that file does not, and must
+not, install this hook.
+
 **Enable on a fresh project:**
 
 ```bash
@@ -86,7 +94,7 @@ CLAUDE.md             → Shared rules: workflow, principles, skills index (both
 .claude/skills/       → Claude Code backwards-compat copy of .agents/skills/
 .claude/agents/       → Subagent definitions (Claude Code only)
 .claude/hooks/        → Lifecycle hooks (Claude Code only)
-.claude/settings.json → Hook configuration (Claude Code only)
+.claude/settings.json → Hook configuration + env (Claude Code only — no SessionStart, see above)
 ```
 
 **Never sync** (project-specific state):
@@ -287,10 +295,43 @@ For each applied file, briefly note what changed.
    - Suggested message: `chore: sync workflow updates from coding-agent-workflow`
 3. Remind the user to review `CLAUDE.md` if it was updated — they may need to merge project-specific customizations back in
 
+### Step 7 — Optional: Re-wire graphify
+
+`graphify` is a per-machine CLI (`~/.local/bin/graphify`) that most projects do not use.
+This step is **optional and non-blocking** — never abort, fail, or roll back a sync
+because of it. Skip silently when the binary is absent:
+
+```bash
+command -v graphify >/dev/null 2>&1 || echo "graphify not installed — skipping"
+```
+
+If it *is* available, note that `/sync` may have just overwritten `CLAUDE.md`, which
+wipes the graphify section written by `graphify claude install`. Re-run the per-project
+wiring to restore it:
+
+```bash
+graphify claude install || true   # CLAUDE.md section + PreToolUse hook
+graphify hook install  || true    # post-commit / post-checkout re-index git hooks
+```
+
+Both are idempotent, so re-running after every sync is expected and harmless.
+`graphify hook status` reports whether the git hooks are already in place if you'd
+rather check before writing.
+
+Then confirm the graph itself isn't stale. Per-project state lives in
+`graphify-out/graph.json`; if it is missing or older than recent commits, refresh it:
+
+```bash
+graphify update . || true
+```
+
+Report the outcome as a single line and move on. Because this runs after the sync is
+already applied, a graphify failure leaves the sync itself fully intact.
+
 ## Edge Cases
 
 - **CLAUDE.md is safe to overwrite**: `CLAUDE.md` contains only shared template rules (workflow, principles, skills index). Project-specific content lives in `.claude/project.md` (Claude Code) or `AGENTS.md` (Pi), which `/sync` never touches. The `@.claude/project.md` and `@CLAUDE.local.md` imports at the top of `CLAUDE.md` are Claude Code layering — they survive the overwrite unchanged since `/sync` replaces the whole file with the same imports.
-- **settings.json merge**: If the project has custom hooks in `.claude/settings.json`, show both versions and help the user merge rather than overwrite.
+- **settings.json merge**: If the project has custom hooks in `.claude/settings.json`, show both versions and help the user merge rather than overwrite. Syncing this file never installs the `SessionStart` drift hook — that is registered once at user level by `install.sh` (see Automatic Drift Notification). If a project's `.claude/settings.json` contains a `SessionStart` entry pointing at `session-start.sh`, it duplicates the user-level registration and makes the banner print twice — flag it for removal.
 - **New files**: Files that exist in the template but not the project are shown as NEW and can be added.
 - **Deleted files**: Files that exist in the project's `.claude/` but NOT in the template are flagged — they may be project-specific additions (don't remove them).
 - **`.claude/project.md` missing in the target project**: expected for fresh projects that haven't run `/setup-deployment` yet. `/sync` does not create it — that happens lazily on first write by `/setup-deployment` or the migration step above.

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -94,6 +94,28 @@ Address any MUST-FIX findings before proceeding to commit.
 
 ---
 
+## Step 3.7 — Shortcut Ledger
+
+`CLAUDE.md` § *Code Economy* marks deliberate shortcuts with `TODO(shortcut):`
+naming a limit and an upgrade path. Collect them so a deferral cannot quietly
+become permanent:
+
+```bash
+grep -rnE '(#|//|--) ?TODO\(shortcut\):' . \
+  --exclude-dir={.git,node_modules,dist,build,vendor} 2>/dev/null || true
+```
+
+One line per marker: `<file>:<line> — <limit>. upgrade: <trigger>.` Tag any
+marker naming no upgrade path `no-trigger` — those are the ones that rot. Close
+with `<N> shortcuts, <M> without a trigger.`
+
+No markers found: print nothing and move on (failure-only reporting, per
+`CLAUDE.md` § *Observability Discipline*). This step reports only — it never
+blocks the commit, and shortcuts are not bugs, so they do not go in
+`tasks/bugs.md`.
+
+---
+
 ## Step 4 — Code Review (4 passes)
 
 Run 4 sequential self-review passes in the main context. For each pass:


### PR DESCRIPTION
Three independent follow-ups surfaced while investigating the failing test suite. Kept off #49 so that one stays a focused rules change; this branch is off `master` and does not depend on it.

**Suite goes from 2/9 files failing → all 9 passing** (211 assertions). Both failures were pre-existing on `master`, not introduced by #49.

Two of these turned out to be more serious than the test names suggested. Reviewers should look hardest at the second one.

## 1. `016fbf5` — sync-skill parity (a live footgun)

`86a1dbc` updated `.agents/skills/sync/SKILL.md` and never mirrored it to the Claude Code copy, leaving it **41 lines behind** (296 vs 337). Three blocks were missing from the tree Claude Code actually reads:

- The warning that `SessionStart` is registered at **user level only**, and that adding it to project `.claude/settings.json` makes the hook fire twice — the entire point of `86a1dbc`, absent from the copy it needed to reach.
- **Step 7, re-wire graphify**: `/sync` overwrites `CLAUDE.md`, wiping the section written by `graphify claude install`, so the restore commands must run after every sync.
- The `settings.json` merge note about flagging duplicate `SessionStart` entries.

**Not cosmetic drift.** Running `/sync` on Claude Code today overwrites `CLAUDE.md`, silently destroys the graphify wiring, and never tells you to restore it — because that step exists only in the Pi copy. The fix `86a1dbc` shipped was never in effect on Claude Code.

Restored by copying the canonical file verbatim. Byte-identical again; parity test 42/42.

## 2. `b054e26` — the compact branch has never fired ⚠️

This is the one worth scrutiny. It was **not** a test artifact.

The compaction-aware restore branch was gated behind `command -v jq`. **`jq` is not on PATH here**, so `HOOK_SOURCE` stayed `startup` on every invocation and the branch never ran — in production, not just under test. The `PreCompact` hook flushes state to `tasks/checkpoint.md` and nothing has been pointing the agent back at it after a compaction: exactly the moment re-orientation matters most.

The old comment called this "no regression" because the full banner still prints. That holds for `startup` and is wrong for `compact`, where the fallback substitutes the heavy first-run banner for the re-orientation block.

Fixed by **removing the dependency rather than adding it** — `sed` extracts the field and `sed` is already required by this script. Per Code Economy, don't add a dependency for what the platform already covers. Installing `jq` would have fixed the symptom and left the hook env-dependent.

Also adds a tty guard so a manual run with no piped stdin can't block on `cat` — previously unreachable, since stdin was only read when `jq` existed.

Verified: `compact` → restore branch; `startup`/`resume`/`clear` → full banner; malformed JSON, empty stdin, no stdin, and odd key spacing all fall back cleanly.

## 3. `d5ac547` — `TODO(shortcut):` gets a reader

Code Economy tells agents to mark deliberate shortcuts with `TODO(shortcut):` naming a limit and an upgrade path. **Nothing ever read them back.** The gate collected its benefit immediately (less code) and deferred its cost (unreviewed limitations) into comments no gate, skill, or hook revisited — "later means never", and invisible, because a shortcut with a dutifully written upgrade path *looks* handled.

The asymmetry this closes: `[AMBIGUITY]` already has a reader (`/build` batches and surfaces them). `TODO(shortcut):` had none.

Adds **Step 3.7** to `/wrap-up-session`, grouped with Step 3.5 `security-scan` since both scan the tree before review. Tags any marker naming no upgrade path `no-trigger` — those are the ones that rot.

Deliberately minimal: no new skill file for one grep (a `/shortcut-debt` skill would fail rungs 1–2 of the hierarchy it enforces), no new register file, and shortcuts don't go in `tasks/bugs.md` because they aren't bugs. Silent when nothing is found, per Observability Discipline. Reports only — never blocks a commit.

Regex verified **positively against fixtures**, not just by a zero-hit run (a broken regex also returns nothing): matches `#`, `//`, `--` with or without a space; rejects plain `TODO`, `FIXME(shortcut)`, and prose that merely mentions the convention. Zero markers exist today, so the ledger starts empty with no backlog.

## Corrects the record in #49

#49's testing section misattributes both failures. Accurate version:

| Failure | #49 says | Actually |
|---|---|---|
| `test-skill-parity.sh` | likely `2b671d1` | `86a1dbc` — verified, the `.claude/` copy's log stops one commit earlier at `7a4f8d8` |
| `test-session-start.sh` | likely `86a1dbc` | no commit — `jq` absent from PATH, a latent gap since the branch was written |

## Not fixed here

The double-invocation comment at `.claude/hooks/session-start.sh:31-37` still describes `SessionStart` as registered both globally and per-project. `86a1dbc` removed the project-level registration, so it's stale — but the guard itself remains useful defence-in-depth, and rewriting the comment isn't this change's job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
