### PR TITLE
feat(workflow): worktree isolation for unattended runs + conflict hygiene

### DIFF
--- a/.agents/skills/auto-improve/SKILL.md
+++ b/.agents/skills/auto-improve/SKILL.md
@@ -30,8 +30,12 @@ The moment you are tempted to bundle a second unrelated fix "while you're here" 
 ## Pre-Flight — Load Context & Guard Rails
 
 1. **Read the working memory**: `tasks/memory.md`, `tasks/lessons.md`, `tasks/todo.md`, `tasks/bugs.md`, `tasks/backlog.md`. Skip any that don't exist.
-2. **Branch safety**: `git rev-parse --abbrev-ref HEAD`. Create a fresh working branch `claude/auto-improve-<date>`; never work on `main`/`master`/`develop`.
-3. **Clean tree**: `git status --short`. If unrelated uncommitted changes exist, surface but do not silently include them in the PR.
+2. **Branch safety, in a worktree — mandatory**: create `claude/auto-improve-<date>` and check it out **in its own git worktree**, never in the shared clone. Never work on `main`/`master`/`develop`.
+
+   This is not optional here the way it is in `/build` Step 0.5. A daily cloud run is unattended by definition, so it is precisely the case where another session or a scheduled job checks out a different branch in the shared clone and rewrites files under a live edit — with nobody watching to notice. It also makes step 3 trivially true: a fresh worktree cannot inherit someone else's uncommitted work, so there is nothing to accidentally sweep into the PR.
+
+   Prefer the harness-native `EnterWorktree` tool; this instruction is what authorises it. Otherwise `scripts/bootstrap-worktree.sh claude/auto-improve-<date>`. Never a bare `git worktree add` — no `node_modules`, no `.env*`, and a suite gated on an env file will skip those tests and report green. The Iron Law forbids a PR on a non-green suite; a *falsely* green one defeats it just as thoroughly.
+3. **Clean tree**: `git status --short` **in the worktree**. It should be empty by construction; if it is not, stop — something is wrong with the bootstrap. Uncommitted changes in the parent clone are not your concern and must not enter the PR.
 4. **Green baseline**: run the full test suite (see `tasks/memory.md` for the exact runner — this project uses `/home/joaosouto/venv/bin/pytest tests/`). If the baseline is RED, that failing test *becomes* the improvement to fix. Do not build on top of a broken baseline.
 
 If a guard cannot be satisfied and it is not itself the thing to fix, STOP and report — do not proceed.

--- a/.agents/skills/auto-push/SKILL.md
+++ b/.agents/skills/auto-push/SKILL.md
@@ -15,6 +15,29 @@ The single approval gate is the whole point. After it, you don't ask again.
 
 ---
 
+## Isolation — mandatory once the gate is passed
+
+Enter a worktree **before `/plan`**, so the branch the user approves is the
+branch that ships. `/build` Step 0.5 treats this as a decision; here it is not.
+
+The approval gate is what makes this unattended. Everything after it — build,
+review, tests, commit, push — runs with nobody watching, which is exactly when a
+concurrent session or a scheduled job checks out another branch in the shared
+clone and rewrites files under a live edit. The user approved a plan; they
+should get that plan, not whatever the tree became.
+
+**How:** prefer the harness-native `EnterWorktree` tool; this instruction is what
+authorises it. Otherwise `scripts/bootstrap-worktree.sh <branch>`.
+
+Never a bare `git worktree add` — no `node_modules`, no `.env*`, and a suite
+gated on an env file will skip those tests and report green. Pushing on a false
+green is worse here than in `/yolo`, because the user believes a human approved
+this one.
+
+`/wrap-up-session` Step 7.5 closes the worktree after the push.
+
+---
+
 ## Model Routing
 
 Sub-agent delegations follow the Model Routing table in `/build` (planner tier for planning/architecture, build tier for coding agents, review tier for reviewers, scout tier for exploration).

--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -31,6 +31,41 @@ Sub-agent model assignment for build orchestration. Edit this table to match you
 
 > **For Pi + OpenRouter users:** Session-level routing goes in `~/.pi/agent/presets.json` (see `PI_SETUP.md`). **Sub-agent** routing requires the `pi-subagents` extension (`pi install npm:pi-subagents`) — set `subagents.agentOverrides` in `~/.pi/agent/settings.json` (agent name → model, plus `fallbackModels` for provider failures). Workflow agents live in `.agents/agents/` and are auto-discovered per project. See `PI_SETUP.md` § Sub-Agent Routing.
 
+## Step 0.5 — Isolation
+
+Decide **before** the green baseline whether this build runs in a git worktree.
+Pairs with `/wrap-up-session` Step 7.5, which merges and removes it.
+
+**Enter a worktree if ANY of these hold:**
+
+- Invoked from `/yolo`, `/auto-improve`, or `/auto-push` — unattended, so nobody
+  is watching to notice a stray checkout
+- Another agent session is active in this clone
+- The plan regenerates committed fixtures or snapshots
+- `tasks/todo.md` has more than 6 open tasks (long enough to straddle a merge)
+
+**Otherwise stay in the clone** and say so in one line. A short supervised build
+does not earn the setup cost.
+
+**How:** prefer the harness-native `EnterWorktree` tool where available — this
+skill instructing it is what authorises that tool. Otherwise:
+
+```bash
+scripts/bootstrap-worktree.sh <branch>
+```
+
+Do not use a bare `git worktree add`. A fresh worktree has no `node_modules` and
+no `.env*`, and a suite that gates on an env file will **skip** those tests and
+report green. The script symlinks and copies both, and warns when it cannot.
+Count the tests, not the exit code.
+
+**What a worktree does and does not buy you.** It prevents *interference* — one
+agent's `checkout` rewriting files under another's running session. It does
+nothing for *merge conflicts*, which come from two branches editing the same
+lines and are identical however many directories were involved. It can even make
+them larger, since agents in separate trees never see each other's work in
+progress and drift further before finding out. Merge `main` in frequently.
+
 ## Pre-Flight Checks
 
 1. Verify `tasks/todo.md` exists and has pending `[ ]` tasks
@@ -65,9 +100,16 @@ Before processing tasks sequentially, assess if any can run in parallel.
 
 **If 2+ independent tasks found**:
 1. Group tasks by independence
-2. Dispatch one sub-agent per independent group
+2. Dispatch one sub-agent per independent group, passing
+   `isolation: "worktree"` on each `Agent` call **when the groups write files**.
+   Independence assessed at plan time is a prediction; worktree isolation makes
+   it structurally true, so a mis-grouping surfaces as a merge conflict you can
+   see rather than two agents silently overwriting each other.
 3. Wait for all to return; check for file conflicts
-4. Run full test suite to verify all changes integrate cleanly
+4. Run the full test suite **centrally, once** — never instruct the sub-agents to
+   run it themselves. Fanning verification out to every agent multiplies context
+   for no added signal and is a known way to lose a whole fleet to autocompact
+   thrashing. Isolate the *edits*, centralise the *verification*.
 
 **If tasks are sequential/dependent**: process one at a time (Steps 1–4 below).
 

--- a/.agents/skills/wrap-up-session/SKILL.md
+++ b/.agents/skills/wrap-up-session/SKILL.md
@@ -224,20 +224,6 @@ If no specs were touched: skip this gate silently.
 
 ---
 
-## Step 6.5 — Worktree Integration (if applicable)
-
-If in a git worktree (`git worktree list`):
-
-1. Verify clean state: all tests pass, no uncommitted changes
-2. Switch to main worktree, pull latest, merge feature branch
-3. Run tests on merged result
-4. If merge conflicts: resolve, re-run tests
-5. Remove worktree and delete feature branch after successful merge
-
-If NOT in a worktree: skip.
-
----
-
 ## Step 7 — Commit & Push
 
 ### Code Review Gate
@@ -266,6 +252,44 @@ If NOT in a worktree: skip.
 | Non-fast-forward | `git pull --rebase`, resolve conflicts, push again |
 | Permission denied | Report to user — do not retry |
 | Branch protection | Report to user — do not retry |
+
+---
+
+## Step 7.5 — Worktree Integration (if applicable)
+
+Runs **after** Step 7, not before it. Merging can only follow committing — the
+previous version of this step ran before the commit, so it either found a dirty
+tree or merged a branch that did not yet contain the session's work.
+
+If NOT in a git worktree: skip. Otherwise check which flow this repo uses.
+
+**If the work goes through a pull request (default when `origin` exists):**
+
+1. Confirm Step 7 pushed the branch: `git status -sb` shows no `ahead`
+2. Open the PR (`gh pr create`) or confirm one is already open
+3. **Stop here. Do not merge locally and do not delete the branch** — an open PR
+   whose source branch is gone is a dead PR, and a local merge to `main` bypasses
+   the review the PR exists to get
+4. Removing the *worktree directory* is fine once pushed
+   (`git worktree remove <path>`); the branch must survive until the PR lands
+
+**If the repo merges locally (no remote, or the user asked for a direct merge):**
+
+1. Verify clean: `git status --porcelain` empty
+2. Switch to the parent worktree, `git pull --ff-only`
+3. `git merge --no-ff <branch>`
+4. Run the **full** suite on the merged result — this is the first time these two
+   lines of history have coexisted, so a green run on either side proves nothing
+   about the merge
+5. Green → `git worktree remove <path>` and delete the branch
+6. Red → keep both, report the failures, change nothing else
+
+**Conflicts.** Expect them in `tasks/*.md` — the append-only registers are
+touched by nearly every session and are a bigger conflict source than source
+code. A `.gitattributes` with `merge=union` on those files removes the mechanical
+conflict but not the semantic one: two sessions that each allocate the next
+`BUG-NNN` produce duplicate IDs with no marker to catch it. After merging, scan
+the register for repeated IDs before trusting it.
 
 ---
 

--- a/.agents/skills/yolo/SKILL.md
+++ b/.agents/skills/yolo/SKILL.md
@@ -28,9 +28,32 @@ Sub-agent delegations follow the Model Routing table in `/build` (planner tier f
 NO USER PROMPTS BETWEEN PHASES.
 PLAN AUTO-CONFIRMS. BUILD RUNS TO COMPLETION. WRAP-UP COMMITS AND PUSHES.
 THE LOOP ONLY EXITS ON: BACKLOG EMPTY, CIRCUIT BREAKER, OR USER INTERRUPT.
+ALWAYS RUN IN A WORKTREE.
 ```
 
 If you find yourself about to ask "should I proceed?" — you are violating yolo mode. The user already said yes by invoking `/yolo`.
+
+---
+
+## Isolation — mandatory, not a judgement call
+
+Enter a worktree **before the first `/plan`**, and stay in it for the whole loop.
+`/build` Step 0.5 treats this as a decision; here it is not one.
+
+The reason is the Iron Law itself. No user prompts means nobody is watching, and
+an unattended loop is exactly when another session — or automation on a
+schedule — checks out a different branch in the shared clone and rewrites the
+files underneath a running edit. Supervised, you notice. Here you do not, and
+the loop keeps building against a tree that silently became something else.
+
+**How:** prefer the harness-native `EnterWorktree` tool; this instruction is what
+authorises it. Otherwise `scripts/bootstrap-worktree.sh <branch>`.
+
+Never a bare `git worktree add` — no `node_modules`, no `.env*`, and a suite
+gated on an env file will skip those tests and report green. An unattended loop
+that trusts a false green will happily build on top of it for hours.
+
+`/wrap-up-session` Step 7.5 closes the worktree at the end of each iteration.
 
 ---
 

--- a/.claude/skills/auto-improve/SKILL.md
+++ b/.claude/skills/auto-improve/SKILL.md
@@ -30,8 +30,12 @@ The moment you are tempted to bundle a second unrelated fix "while you're here" 
 ## Pre-Flight — Load Context & Guard Rails
 
 1. **Read the working memory**: `tasks/memory.md`, `tasks/lessons.md`, `tasks/todo.md`, `tasks/bugs.md`, `tasks/backlog.md`. Skip any that don't exist.
-2. **Branch safety**: `git rev-parse --abbrev-ref HEAD`. Create a fresh working branch `claude/auto-improve-<date>`; never work on `main`/`master`/`develop`.
-3. **Clean tree**: `git status --short`. If unrelated uncommitted changes exist, surface but do not silently include them in the PR.
+2. **Branch safety, in a worktree — mandatory**: create `claude/auto-improve-<date>` and check it out **in its own git worktree**, never in the shared clone. Never work on `main`/`master`/`develop`.
+
+   This is not optional here the way it is in `/build` Step 0.5. A daily cloud run is unattended by definition, so it is precisely the case where another session or a scheduled job checks out a different branch in the shared clone and rewrites files under a live edit — with nobody watching to notice. It also makes step 3 trivially true: a fresh worktree cannot inherit someone else's uncommitted work, so there is nothing to accidentally sweep into the PR.
+
+   Prefer the harness-native `EnterWorktree` tool; this instruction is what authorises it. Otherwise `scripts/bootstrap-worktree.sh claude/auto-improve-<date>`. Never a bare `git worktree add` — no `node_modules`, no `.env*`, and a suite gated on an env file will skip those tests and report green. The Iron Law forbids a PR on a non-green suite; a *falsely* green one defeats it just as thoroughly.
+3. **Clean tree**: `git status --short` **in the worktree**. It should be empty by construction; if it is not, stop — something is wrong with the bootstrap. Uncommitted changes in the parent clone are not your concern and must not enter the PR.
 4. **Green baseline**: run the full test suite (see `tasks/memory.md` for the exact runner — this project uses `/home/joaosouto/venv/bin/pytest tests/`). If the baseline is RED, that failing test *becomes* the improvement to fix. Do not build on top of a broken baseline.
 
 If a guard cannot be satisfied and it is not itself the thing to fix, STOP and report — do not proceed.

--- a/.claude/skills/auto-push/SKILL.md
+++ b/.claude/skills/auto-push/SKILL.md
@@ -15,6 +15,29 @@ The single approval gate is the whole point. After it, you don't ask again.
 
 ---
 
+## Isolation — mandatory once the gate is passed
+
+Enter a worktree **before `/plan`**, so the branch the user approves is the
+branch that ships. `/build` Step 0.5 treats this as a decision; here it is not.
+
+The approval gate is what makes this unattended. Everything after it — build,
+review, tests, commit, push — runs with nobody watching, which is exactly when a
+concurrent session or a scheduled job checks out another branch in the shared
+clone and rewrites files under a live edit. The user approved a plan; they
+should get that plan, not whatever the tree became.
+
+**How:** prefer the harness-native `EnterWorktree` tool; this instruction is what
+authorises it. Otherwise `scripts/bootstrap-worktree.sh <branch>`.
+
+Never a bare `git worktree add` — no `node_modules`, no `.env*`, and a suite
+gated on an env file will skip those tests and report green. Pushing on a false
+green is worse here than in `/yolo`, because the user believes a human approved
+this one.
+
+`/wrap-up-session` Step 7.5 closes the worktree after the push.
+
+---
+
 ## Model Routing
 
 Sub-agent delegations follow the Model Routing table in `/build` (planner tier for planning/architecture, build tier for coding agents, review tier for reviewers, scout tier for exploration).

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -31,6 +31,41 @@ Sub-agent model assignment for build orchestration. Edit this table to match you
 
 > **For Pi + OpenRouter users:** Session-level routing goes in `~/.pi/agent/presets.json` (see `PI_SETUP.md`). **Sub-agent** routing requires the `pi-subagents` extension (`pi install npm:pi-subagents`) — set `subagents.agentOverrides` in `~/.pi/agent/settings.json` (agent name → model, plus `fallbackModels` for provider failures). Workflow agents live in `.agents/agents/` and are auto-discovered per project. See `PI_SETUP.md` § Sub-Agent Routing.
 
+## Step 0.5 — Isolation
+
+Decide **before** the green baseline whether this build runs in a git worktree.
+Pairs with `/wrap-up-session` Step 7.5, which merges and removes it.
+
+**Enter a worktree if ANY of these hold:**
+
+- Invoked from `/yolo`, `/auto-improve`, or `/auto-push` — unattended, so nobody
+  is watching to notice a stray checkout
+- Another agent session is active in this clone
+- The plan regenerates committed fixtures or snapshots
+- `tasks/todo.md` has more than 6 open tasks (long enough to straddle a merge)
+
+**Otherwise stay in the clone** and say so in one line. A short supervised build
+does not earn the setup cost.
+
+**How:** prefer the harness-native `EnterWorktree` tool where available — this
+skill instructing it is what authorises that tool. Otherwise:
+
+```bash
+scripts/bootstrap-worktree.sh <branch>
+```
+
+Do not use a bare `git worktree add`. A fresh worktree has no `node_modules` and
+no `.env*`, and a suite that gates on an env file will **skip** those tests and
+report green. The script symlinks and copies both, and warns when it cannot.
+Count the tests, not the exit code.
+
+**What a worktree does and does not buy you.** It prevents *interference* — one
+agent's `checkout` rewriting files under another's running session. It does
+nothing for *merge conflicts*, which come from two branches editing the same
+lines and are identical however many directories were involved. It can even make
+them larger, since agents in separate trees never see each other's work in
+progress and drift further before finding out. Merge `main` in frequently.
+
 ## Pre-Flight Checks
 
 1. Verify `tasks/todo.md` exists and has pending `[ ]` tasks
@@ -65,9 +100,16 @@ Before processing tasks sequentially, assess if any can run in parallel.
 
 **If 2+ independent tasks found**:
 1. Group tasks by independence
-2. Dispatch one sub-agent per independent group
+2. Dispatch one sub-agent per independent group, passing
+   `isolation: "worktree"` on each `Agent` call **when the groups write files**.
+   Independence assessed at plan time is a prediction; worktree isolation makes
+   it structurally true, so a mis-grouping surfaces as a merge conflict you can
+   see rather than two agents silently overwriting each other.
 3. Wait for all to return; check for file conflicts
-4. Run full test suite to verify all changes integrate cleanly
+4. Run the full test suite **centrally, once** — never instruct the sub-agents to
+   run it themselves. Fanning verification out to every agent multiplies context
+   for no added signal and is a known way to lose a whole fleet to autocompact
+   thrashing. Isolate the *edits*, centralise the *verification*.
 
 **If tasks are sequential/dependent**: process one at a time (Steps 1–4 below).
 

--- a/.claude/skills/wrap-up-session/SKILL.md
+++ b/.claude/skills/wrap-up-session/SKILL.md
@@ -224,20 +224,6 @@ If no specs were touched: skip this gate silently.
 
 ---
 
-## Step 6.5 — Worktree Integration (if applicable)
-
-If in a git worktree (`git worktree list`):
-
-1. Verify clean state: all tests pass, no uncommitted changes
-2. Switch to main worktree, pull latest, merge feature branch
-3. Run tests on merged result
-4. If merge conflicts: resolve, re-run tests
-5. Remove worktree and delete feature branch after successful merge
-
-If NOT in a worktree: skip.
-
----
-
 ## Step 7 — Commit & Push
 
 ### Code Review Gate
@@ -266,6 +252,44 @@ If NOT in a worktree: skip.
 | Non-fast-forward | `git pull --rebase`, resolve conflicts, push again |
 | Permission denied | Report to user — do not retry |
 | Branch protection | Report to user — do not retry |
+
+---
+
+## Step 7.5 — Worktree Integration (if applicable)
+
+Runs **after** Step 7, not before it. Merging can only follow committing — the
+previous version of this step ran before the commit, so it either found a dirty
+tree or merged a branch that did not yet contain the session's work.
+
+If NOT in a git worktree: skip. Otherwise check which flow this repo uses.
+
+**If the work goes through a pull request (default when `origin` exists):**
+
+1. Confirm Step 7 pushed the branch: `git status -sb` shows no `ahead`
+2. Open the PR (`gh pr create`) or confirm one is already open
+3. **Stop here. Do not merge locally and do not delete the branch** — an open PR
+   whose source branch is gone is a dead PR, and a local merge to `main` bypasses
+   the review the PR exists to get
+4. Removing the *worktree directory* is fine once pushed
+   (`git worktree remove <path>`); the branch must survive until the PR lands
+
+**If the repo merges locally (no remote, or the user asked for a direct merge):**
+
+1. Verify clean: `git status --porcelain` empty
+2. Switch to the parent worktree, `git pull --ff-only`
+3. `git merge --no-ff <branch>`
+4. Run the **full** suite on the merged result — this is the first time these two
+   lines of history have coexisted, so a green run on either side proves nothing
+   about the merge
+5. Green → `git worktree remove <path>` and delete the branch
+6. Red → keep both, report the failures, change nothing else
+
+**Conflicts.** Expect them in `tasks/*.md` — the append-only registers are
+touched by nearly every session and are a bigger conflict source than source
+code. A `.gitattributes` with `merge=union` on those files removes the mechanical
+conflict but not the semantic one: two sessions that each allocate the next
+`BUG-NNN` produce duplicate IDs with no marker to catch it. After merging, scan
+the register for repeated IDs before trusting it.
 
 ---
 

--- a/.claude/skills/yolo/SKILL.md
+++ b/.claude/skills/yolo/SKILL.md
@@ -28,9 +28,32 @@ Sub-agent delegations follow the Model Routing table in `/build` (planner tier f
 NO USER PROMPTS BETWEEN PHASES.
 PLAN AUTO-CONFIRMS. BUILD RUNS TO COMPLETION. WRAP-UP COMMITS AND PUSHES.
 THE LOOP ONLY EXITS ON: BACKLOG EMPTY, CIRCUIT BREAKER, OR USER INTERRUPT.
+ALWAYS RUN IN A WORKTREE.
 ```
 
 If you find yourself about to ask "should I proceed?" — you are violating yolo mode. The user already said yes by invoking `/yolo`.
+
+---
+
+## Isolation — mandatory, not a judgement call
+
+Enter a worktree **before the first `/plan`**, and stay in it for the whole loop.
+`/build` Step 0.5 treats this as a decision; here it is not one.
+
+The reason is the Iron Law itself. No user prompts means nobody is watching, and
+an unattended loop is exactly when another session — or automation on a
+schedule — checks out a different branch in the shared clone and rewrites the
+files underneath a running edit. Supervised, you notice. Here you do not, and
+the loop keeps building against a tree that silently became something else.
+
+**How:** prefer the harness-native `EnterWorktree` tool; this instruction is what
+authorises it. Otherwise `scripts/bootstrap-worktree.sh <branch>`.
+
+Never a bare `git worktree add` — no `node_modules`, no `.env*`, and a suite
+gated on an env file will skip those tests and report green. An unattended loop
+that trusts a false green will happily build on top of it for hours.
+
+`/wrap-up-session` Step 7.5 closes the worktree at the end of each iteration.
 
 ---
 

--- a/project-template/.gitattributes
+++ b/project-template/.gitattributes
@@ -1,0 +1,46 @@
+# Conflict hygiene for multi-agent work.
+#
+# When several agent sessions run against one repo, the top conflict sources are
+# usually not source files — they are the workflow's own append-only registers.
+# Every session ends by appending to them, so N concurrent sessions means N
+# collisions on files unrelated to the features being built.
+#
+# Measured on one project, last 200 commits:
+#   51  tasks/bugs.md      <- 25% of all commits
+#   43  tasks/todo.md
+#   39  tasks/lessons.md
+#   24  lib/services/<busiest source file>
+#
+# `merge=union` keeps both sides with no conflict markers, which is right for a
+# log that only ever grows.
+#
+# READ THIS BEFORE RELYING ON IT: union merge resolves the *textual* conflict,
+# not the *semantic* one. Two agents that both grep for the last ID and both
+# pick BUG-144 will get two BUG-144 entries and no marker to catch it. Union is
+# a mitigation; the real fix is IDs that need no coordination (timestamp or
+# branch slug), or one-file-per-entry with a thin index — see
+# `.agents/skills/wrap-up-session/SKILL.md`.
+
+tasks/bugs.md        merge=union
+tasks/lessons.md     merge=union
+tasks/backlog.md     merge=union
+tasks/design-debt.md merge=union
+tasks/e2e-log.md     merge=union
+
+# NOT union-merged, deliberately:
+#   tasks/todo.md      rewritten wholesale per plan, not appended. Union would
+#                      splice two unrelated plans into one incoherent list.
+#   tasks/memory.md    curated and consolidated by /memory-maintain; union
+#                      defeats the deduplication that skill exists to perform.
+
+# Lockfiles: never merge, always regenerate. A textually merged lockfile can be
+# internally inconsistent while looking clean.
+package-lock.json -merge
+pnpm-lock.yaml    -merge
+yarn.lock         -merge
+
+# Committed binary fixtures: no textual merge is meaningful. Regenerate from a
+# detached worktree at HEAD instead (scripts/bootstrap-worktree.sh --detach-head).
+*.png binary
+*.jpg binary
+*.pdf binary

--- a/scripts/bootstrap-worktree.sh
+++ b/scripts/bootstrap-worktree.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Create an agent worktree that can actually run the test suite.
+#
+# A fresh `git worktree add` gives you tracked files and nothing else. Everything
+# gitignored — node_modules, .env*, build caches — is absent. That matters more
+# than it sounds: a suite that gates on `.env.test` will *skip* those tests in a
+# bare worktree and report green. A worktree without this bootstrap produces
+# false confidence, which is worse than no worktree at all.
+#
+# Usage:
+#   scripts/bootstrap-worktree.sh <branch> [path]
+#   scripts/bootstrap-worktree.sh --detach-head <path>   # for fixture regeneration
+#
+# Defaults path to ../<repo>-<branch-slug>.
+set -euo pipefail
+
+die() { printf 'bootstrap-worktree: %s\n' "$1" >&2; exit 1; }
+
+[ $# -ge 1 ] || die "usage: bootstrap-worktree.sh <branch> [path] | --detach-head <path>"
+
+git rev-parse --git-dir >/dev/null 2>&1 || die "not a git repository"
+MAIN="$(git rev-parse --show-toplevel)"
+REPO="$(basename "$MAIN")"
+
+if [ "$1" = "--detach-head" ]; then
+  [ $# -ge 2 ] || die "--detach-head requires a path"
+  WT="$2"; DETACHED=1; BRANCH=""
+else
+  BRANCH="$1"; DETACHED=0
+  slug="$(printf '%s' "$BRANCH" | tr '/' '-')"
+  WT="${2:-$MAIN/../$REPO-$slug}"
+fi
+
+[ -e "$WT" ] && die "path already exists: $WT"
+
+# --- create ------------------------------------------------------------------
+if [ "$DETACHED" -eq 1 ]; then
+  # Pinned to HEAD with no branch. This is the only safe tree for regenerating
+  # committed fixtures: a dirty working tree bakes unrelated WIP into an
+  # artefact that then fails only in CI.
+  git worktree add --detach "$WT" HEAD >/dev/null
+elif git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git worktree add "$WT" "$BRANCH" >/dev/null
+else
+  git worktree add -b "$BRANCH" "$WT" >/dev/null
+fi
+WT="$(cd "$WT" && pwd)"   # normalise before we link into it
+
+# --- node_modules ------------------------------------------------------------
+# Symlink rather than reinstall: saves minutes and disk, and guarantees both
+# trees resolve identical dependency versions. Safe because the lockfile is
+# tracked, so a worktree that changes deps changes the lockfile too — and that
+# case wants its own install, see the warning below.
+if [ -d "$MAIN/node_modules" ]; then
+  ln -s "$MAIN/node_modules" "$WT/node_modules"
+  echo "  linked  node_modules -> $MAIN/node_modules"
+else
+  echo "  skipped node_modules (absent in $MAIN; run your install in the worktree)"
+fi
+
+# --- gitignored config -------------------------------------------------------
+# The whole reason this script exists. These are never inherited by a worktree.
+copied=0
+for f in "$MAIN"/.env "$MAIN"/.env.*; do
+  [ -e "$f" ] || continue
+  case "$(basename "$f")" in *.example|*.sample|*.template) continue ;; esac
+  cp "$f" "$WT/" && copied=$((copied + 1))
+done
+if [ "$copied" -gt 0 ]; then
+  echo "  copied  $copied env file(s)"
+else
+  echo "  WARNING no .env* found in $MAIN — if the suite gates on one, it will"
+  echo "          silently skip those tests and report green."
+fi
+
+# --- report ------------------------------------------------------------------
+cat <<EOF
+
+worktree ready: $WT
+$( [ "$DETACHED" -eq 1 ] && echo "  detached at HEAD $(git rev-parse --short HEAD)" || echo "  branch: $BRANCH" )
+
+  cd $WT
+
+Before trusting a green run, confirm the suite is not skipping gated tests —
+count the tests, not the exit code.
+
+If this worktree changes dependencies, replace the node_modules symlink with a
+real install first; writing through the link mutates the parent's tree.
+
+Remove when done:  git worktree remove $WT
+EOF


### PR DESCRIPTION
Two related gaps, both surfaced by a live session losing its working tree to a concurrent checkout mid-run.

## 1. The worktree exit ramp had no on-ramp

`wrap-up-session` already had a **Worktree Integration** step. Nothing anywhere ever *created* a worktree, so it was unreachable — it could only fire if you happened to make one by hand.

| Skill | Behaviour |
|---|---|
| `/build` | **Step 0.5**, self-gating on 4 conditions — a short supervised build doesn't earn the setup cost |
| `/yolo` | **mandatory** — the Iron Law forbids prompts, so nobody is watching |
| `/auto-push` | **mandatory** after the approval gate |
| `/auto-improve` | **mandatory**; also makes its clean-tree check true by construction |

Prefers the harness-native `EnterWorktree` tool. That tool may only be used when the user or project instructions authorise it — a skill instructing it *is* that authorisation.

Also adds `isolation: "worktree"` guidance for parallel sub-agent dispatch in `/build`, paired with an explicit "run the suite **centrally, once**" rule. Isolate the edits, centralise the verification.

## 2. `scripts/bootstrap-worktree.sh` — because bare `git worktree add` is a trap

A fresh worktree has **no `node_modules` and no `.env*`**. A suite gated on an env file will *skip* those tests and report green.

For an unattended loop that is worse than no worktree at all — it builds for hours on false confidence. The script symlinks `node_modules`, copies `.env*` (excluding `.example`/`.sample`/`.template`), and warns loudly when it can't. `--detach-head` mode covers fixture regeneration.

Verified end to end against a throwaway repo: symlink created, env copied, `.example` correctly excluded, branch checked out, HEAD genuinely detached in detach mode, and both error paths exit 1.

## 3. Ordering defect in `wrap-up-session` (found while wiring this up)

Step 6.5 ran **before** Step 7 committed. So it either hit a dirty tree or merged a branch that didn't yet contain the session's work. Merging can only follow committing.

Renumbered to **Step 7.5** and split by flow. The old step unconditionally merged to `main` locally and deleted the branch — which bypasses the review a PR exists to get, and leaves an open PR whose source branch is gone. PR repos now push and **stop**.

## 4. `project-template/.gitattributes` — the conflicts worktrees *don't* fix

Worktrees prevent **interference** (one agent's checkout rewriting another's files). They do nothing for **merge conflicts**, and can make them larger, since isolated agents drift further before finding out.

Measured on one project, last 200 commits — 4 of the top 5 conflict hotspots are the workflow's own bookkeeping, not source:

\`\`\`
51  tasks/bugs.md      <- 25% of all commits
43  tasks/todo.md
39  tasks/lessons.md
24  lib/services/<busiest source file>
19  tasks/backlog.md
\`\`\`

`merge=union` on the append-only registers. `todo.md` and `memory.md` are **deliberately excluded** — the first is rewritten wholesale per plan (union would splice two unrelated plans together), the second is curated by `/memory-maintain` (union defeats the deduplication it exists to perform). Lockfiles get `-merge`.

**Documented hazard union does not fix:** two sessions that each grep for the last ID and both pick `BUG-144` produce duplicate IDs with *no conflict marker*. Union is a mitigation; the real fix is coordination-free IDs or one-file-per-entry with a thin index.

## Testing

9/9 pass, including `test-skill-parity.sh`. All five edited skills copied byte-identical to `.claude/skills/`.

> Note: these tests need `bash`, not `sh` — `test-skill-parity.sh` uses process substitution and reports a spurious syntax-error failure under `sh`.

## Review notes

- The `/build` gate is deliberately **conditional**. Blanket worktrees would tax every quick supervised fix for a risk only unattended runs carry.
- `.gitattributes` ships in `project-template/`, so it reaches new projects via scaffolding but does not retro-apply to existing ones. Existing projects need it copied manually — say the word and I'll add it to `/sync`.
- The measured hotspot numbers come from one project (`pix-receipt-tracker`). The shape is likely general since it follows from the workflow itself, but the exact ratios are one data point.